### PR TITLE
Rename repository from practical-llms to sherpa

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We love your input! We want to make contributing to this project as easy and tra
 - Becoming a maintainer
 
 
-## Report bugs and suggest improvements using Github's [issues](https://github.com/Aggregate-Intellect/practical-llms/issues)
+## Report bugs and suggest improvements using Github's [issues](https://github.com/Aggregate-Intellect/sherpa/issues)
 We use GitHub issues to track public bugs and feature requests. Report a bug or suggest an improvement by [opening a new issue](); it's that easy!
 
 That said, we avoid keeping a massive backlog of "someday, maybe" ideas. We periodically review the issues list so that all issues are things we have a reasonably high likelihood of acting on.
@@ -34,9 +34,9 @@ People *love* thorough bug reports. I'm not even kidding.
 We use GitHub to host code and documentation, track issues and feature requests, and accept pull requests. Here's how it works:
 
 ### The origin/main branch on GitHub is "The Truth"
-The `practical-llms` git repository hosted at https://github.com/Aggregate-Intellect/practical-llms is the primary repository. In terms of git remotes we refer to this repository as **`origin`**.
+https://github.com/Aggregate-Intellect/sherpa is the primary repository. In terms of git remotes we refer to this repository as **`origin`**.
 
-The [`origin/main` branch](https://github.com/Aggregate-Intellect/practical-llms/tree/main) is the "one source of truth". This is what we run in production. Every other branch, including remote branches and forks, derives from
+The [`origin/main` branch](https://github.com/Aggregate-Intellect/sherpa/tree/main) is the "one source of truth". This is what we run in production. Every other branch, including remote branches and forks, derives from
 origin/main.
 
 ### We try to keep `origin/main` deployable at all times
@@ -97,7 +97,7 @@ When you create a branch to contain your changes, you start by forking the HEAD 
 
 If you have not yet created a Pull Request, you can rebase on your own by merging the latest commits from `origin/main` into your local repository's `main` branch and then using `git rebase main`. Rebase will "replay" your commits atop the HEAD of the `main` branch. Git rebase can be a bit tricky to use, so if you aren't familiar with it then start with a good primer like the [BitBucket rebase tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 
-If you have already submitted a Pull Request and you don't have permission to write to https://github.com/Aggregate-Intellect/practical-llms, one of the maintainers can rebase/update the PR on your behalf, e.g. via [GitHub's Update Branch feature](https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/
+If you have already submitted a Pull Request and you don't have permission to write to https://github.com/Aggregate-Intellect/sherpa, one of the maintainers can rebase/update the PR on your behalf, e.g. via [GitHub's Update Branch feature](https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/
 ) or by running `git rebase main` on their own clone of the repo.  
 
 

--- a/docs/KnowledgeOps/rise_of_knowledgeops.rst
+++ b/docs/KnowledgeOps/rise_of_knowledgeops.rst
@@ -10,7 +10,7 @@ effectiveness. KnowledgeOps promises to enhance our ability to
 experiment with a wider range of ideas and select the most impactful
 ones, similar to the benefits seen in DevOps and related methodologies.
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/KnowledgeOps/Knowledge-Ops.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/KnowledgeOps/Knowledge-Ops.pdf>`__
 \| `RECORDING <https://youtu.be/H3jZfLWpOZc>`__
 
 **TWITTER THREAD SUMMARY OF THE TALK:**

--- a/docs/LLM Engineering/llms_in_enterprise.rst
+++ b/docs/LLM Engineering/llms_in_enterprise.rst
@@ -10,7 +10,7 @@ agents. With these insights, he explains how LLMs will shape enterprise
 analytics. Along the way, he covers many practical factors, such as the
 different providers of LLMs, resource costs, and ethical issues.
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM%20Engineering/Enterprise_LLMs_Shah.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM%20Engineering/Enterprise_LLMs_Shah.pdf>`__
 \| `RECORDING <https://youtu.be/GO6l7dbZIqY>`__
 
 **TWITTER THREAD SUMMARY OF THE TALK:**
@@ -93,7 +93,7 @@ different providers of LLMs, resource costs, and ethical issues.
 *Resources*
 
 -  `Talk
-   Slides <https://github.com/Aggregate-Intellect/practical-llms/blob/main/Enterprise_LLMs_Shah.pdf>`__
+   Slides <https://github.com/Aggregate-Intellect/sherpa/blob/main/Enterprise_LLMs_Shah.pdf>`__
 -  `Sentiment Spin: Attacking Financial Sentiment with
    GPT-3 <https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4337182>`__
 -  `Is ChatGPT a General-Purpose Natural Language Processing Task

--- a/docs/LLM Foundations/finetuning.rst
+++ b/docs/LLM Foundations/finetuning.rst
@@ -9,7 +9,7 @@ Additionally, we will delve into computational aspects like scaling
 laws, parameter-efficient fine-tuning (PEFT), and the zero redundancy
 optimizer (ZeRO).
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/main/docs/LLM%20Foundations/FT_LLMs_EK.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/main/docs/LLM%20Foundations/FT_LLMs_EK.pdf>`__
 \| `RECORDING <https://youtu.be/Bn2ZK_ctPbo>`__
 
 **SUMMARY**

--- a/docs/LLM Use Cases/innovation.rst
+++ b/docs/LLM Use Cases/innovation.rst
@@ -8,7 +8,7 @@ organizational processes. He will share lessons learned from his work
 with a bootstrapped startup and provide insights on how LLMs can be
 commercialized effectively.
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM%20Use%20Cases/Commercialization%20Strategy%20with%20LLMs.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM%20Use%20Cases/Commercialization%20Strategy%20with%20LLMs.pdf>`__
 \| `RECORDING <https://youtu.be/QfX648IZg3U>`__
 
 **SUMMARY**

--- a/docs/LLM_Agents/data_generation.rst
+++ b/docs/LLM_Agents/data_generation.rst
@@ -8,7 +8,7 @@ which LLMs generate fine-tuning data that helps them learn how to use
 tools at run-time. In this talk, we’ll examine this trend by taking a
 close look at the Toolformer paper and other related research.
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM_Agents/Self-Improving%20LLMs.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/LLM_Agents/Self-Improving%20LLMs.pdf>`__
 \| `RECORDING <https://youtu.be/Zk_UcqvTTAA>`__
 
 **SUMMARY**

--- a/docs/Research Papers/rlprompt.rst
+++ b/docs/Research Papers/rlprompt.rst
@@ -8,7 +8,7 @@ talk will introduce RLPrompt, an efficient algorithm that uses
 reinforcement learning to systematically search for the best prompts to
 improve LLM performance across diverse tasks.
 
-`SLIDES <https://github.com/Aggregate-Intellect/practical-llms/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/Research%20Papers/RLPrompt%20Presentation.pdf>`__
+`SLIDES <https://github.com/Aggregate-Intellect/sherpa/blob/dffaaf08ea7092561d66532c67d304fd79bab328/docs/Research%20Papers/RLPrompt%20Presentation.pdf>`__
 \| `RECORDING <https://youtu.be/SGInyKjzF7A>`__
 
 **TWITTER THREAD SUMMARY OF THE TALK:**

--- a/docs/Tutorials/slackbot.rst
+++ b/docs/Tutorials/slackbot.rst
@@ -34,7 +34,7 @@ Next, we will create a new Slack app and add it to the Slack Workspace we just c
 
 Run the Slackbot Locally
 ************************
-Next, we will run the slack app project locally. The slackapp project is part of this livebook's repository. If you haven't done so, clone the repository for this livebook at https://github.com/Aggregate-Intellect/practical-llms. 
+Next, we will run the slack app project locally. The slackapp project is part of this livebook's repository. If you haven't done so, clone the repository for this livebook at https://github.com/Aggregate-Intellect/sherpa. 
 
 After you clone the repository, you can find the slackbot project under `apps/slackbot`. The `README` of the slackbot contains instruction to run the app with docker or a virtual environment, we will repeat the instruction with a local virual environment.
 
@@ -144,4 +144,4 @@ Have fun! And please join our `slack channel <https://aisc-to.slack.com/ssb/redi
 Further Reading
 ****************************
 * `Slack API <https://api.slack.com/>`__
-* `SlackBot <https://github.com/Aggregate-Intellect/practical-llms/tree/main/apps/slackbot>`__
+* `SlackBot <https://github.com/Aggregate-Intellect/sherpa/tree/main/apps/slackbot>`__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ This book contains notes, videos, slides, and resources from the workshops and j
 Our mission is to create an ecosystem of experts, ideas, tools, and a community that build together until we get to a point where no idea is too expensive to try.
 
 .. note::
-   In order to contribute to this open book, visit: https://github.com/Aggregate-Intellect/practical-llms
+   In order to contribute to this open book, visit: https://github.com/Aggregate-Intellect/sherpa
 
 CONTENT
 ^^^^^^^


### PR DESCRIPTION
Update repo hyperlinks and references from `practical-llms` to `sherpa`
to support the recent renaming of the repository in GitHub.