### PR TITLE
Enable debugging mode for local development (v2)

### DIFF
--- a/apps/slackbot/.env-sample
+++ b/apps/slackbot/.env-sample
@@ -1,3 +1,6 @@
+# Flask debug mode. Optional. Useful for local development. Never use this in production.
+FLASK_DEBUG=True                   # True or False
+
 # OpenAI. Mandatory. Enables language modeling.
 OPENAI_API_KEY=                     # OpenAI API key 
 

--- a/apps/slackbot/README.md
+++ b/apps/slackbot/README.md
@@ -62,6 +62,7 @@ This repository contains a chatbot implementation using Flask and Slack. The cha
     * **NOTE:** When adding the url to the Slack app, make sure to append `/slack/events` at the end as this is the default path used by Slack Bolt.
 
 ## Development
+
 ### Linting and formating
 This project uses `flake8` for linting, `black` and `isort` for formatting, and `pytest` for testing. To install the dependencies, run:
 
@@ -107,8 +108,33 @@ or
 pytest .
 ```
 
+### Debugging
+The Slackbot is built with Flask, which provides a built-in web server and debugger suitable for development use.
 
-# Reference 
+When Flask debug mode is enabled, ...
+- the server automatically reloads when code is changed
+- http://localhost:3000/ serves a web-based debugger which displays an interactive stack trace when an exception is raised
+- http://localhost:3000/test_debug raises an exception so you can try out the debugger
+- http://localhost:3000/console displays a web-based console where you can execute Python expressions in the context of the application
+- stack traces are also displayed in your terminal console
+
+When Flask debug mode is disabled, ...
+- you must manually restart the server to pick up code changes
+- the web-based debugger and console are not available
+- stack traces are only displayed in your terminal console
+
+To enable debug mode, set `FLASK_DEBUG` to `True` in your `.env` file.
+To disable debug mode, comment out `FLASK_DEBUG` or set it to any value other than `True`.
+
+**Warning:**
+Never use the development server or enable the debugger when deploying to production.
+These tools are intended for use only during local development, and are not designed to
+be particularly efficient, stable, or secure.
+
+For more info on the debugger see [Werkzeug: Debugging Applications](https://werkzeug.palletsprojects.com/en/2.3.x/debug/#)
+and [Flask: Debugging Application Errors](https://flask.palletsprojects.com/en/2.3.x/debugging/).
+
+# Reference
 4.  Start interacting with the chatbot by mentioning the app in a Slack channel.
 
 

--- a/apps/slackbot/bolt_app.py
+++ b/apps/slackbot/bolt_app.py
@@ -121,15 +121,17 @@ def update_home_tab(client, event, logger):
 ###########################################################################
 # Setup Flask app:
 ###########################################################################
-
 flask_app = Flask(__name__)
 handler = SlackRequestHandler(app)
 
+if cfg.FLASK_DEBUG:
+  @flask_app.route("/test_debug", methods=["GET"])
+  def test_debug():
+      raise
 
 @flask_app.route("/slack/events", methods=["POST"])
 def slack_events():
     return handler.handle(request)
-
 
 @flask_app.route("/hello", methods=["GET"])
 def hello():
@@ -144,7 +146,7 @@ if __name__ == "__main__":
 
     # chain = createIndex("files")
     print("App init: starting HTTP server on port {port}".format(port=cfg.SLACK_PORT))
-    flask_app.run(host="0.0.0.0", port=cfg.SLACK_PORT)
+    flask_app.run(host="0.0.0.0", port=cfg.SLACK_PORT, debug=cfg.FLASK_DEBUG)
     # SocketModeHandler(app, cfg.SLACK_APP_TOKEN).start()
 
 

--- a/apps/slackbot/config.py
+++ b/apps/slackbot/config.py
@@ -19,10 +19,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-print(environ.get("SLACK_VERIFICATION_TOKEN"))
-
 AWS_ACCESS_KEY = environ.get("AWS_ACCESS_KEY")
 AWS_SECRET_KEY = environ.get("AWS_SECRET_KEY")
+FLASK_DEBUG = environ.get("FLASK_DEBUG", False) == "True"
 GITHUB_AUTH_TOKEN = environ.get("GITHUB_AUTH_TOKEN")
 SLACK_SIGNING_SECRET = environ.get("SLACK_SIGNING_SECRET")
 SLACK_OAUTH_TOKEN = environ.get("SLACK_OAUTH_TOKEN")


### PR DESCRIPTION
Add support for Flask debugging mode during local development, so that code changes are automatically reloaded and developers can access interactive stack traces and Python console.

See apps/slackbot/README.md for instructions.

Fixes #101.

Replaces https://github.com/Aggregate-Intellect/sherpa/pull/104.

@20001LastOrder could you please review?