### PR TITLE
Switch logger to Loguru to improve logging

### DIFF
--- a/apps/slackbot/bolt_app.py
+++ b/apps/slackbot/bolt_app.py
@@ -3,7 +3,7 @@
 #  Importing necessary modules
 ##############################################
 
-import logging
+from loguru import logger
 
 from flask import Flask, request
 from langchain.chat_models import ChatOpenAI
@@ -16,7 +16,6 @@ from task_agent import TaskAgent
 from tools import get_tools
 from vectorstores import ConversationStore, LocalChromaStore
 
-logger = logging.getLogger(__name__)
 #######################################################################################
 # Set up Slack client and Chroma database
 #######################################################################################
@@ -133,8 +132,8 @@ def event_test(client, say, event):
         question=question, slack_message=[replies["messages"][-1]]
     )
     question = reconstructor.reconstruct_prompt()
-
     results, verbose_message = get_response(question, previous_messages)
+   
     say(results, thread_ts=thread_ts)
 
     if contains_verbose(question):

--- a/apps/slackbot/config.py
+++ b/apps/slackbot/config.py
@@ -11,7 +11,7 @@ Usage:
     another_variable = cfg.ANOTHER_ENVIRONMENT_VARIABLE
 """
 
-import logging
+from loguru import logger
 import sys
 from os import environ
 
@@ -35,13 +35,14 @@ PINECONE_INDEX = environ.get("PINECONE_INDEX")
 SERPER_API_KEY = environ.get("SERPER_API_KEY")
 LOGLEVEL = environ.get("LOG_LEVEL", "INFO").upper()
 
+# Configure logger. To get JSON serialization, set serialize=True.
+# See https://loguru.readthedocs.io/en/stable/ for info on Loguru features.
+logger.remove(0) # remove the default handler configuration
+logger.add(sys.stderr, level=LOGLEVEL, serialize=False)
+
+
 # `this` is a pointer to the module object instance itself.
 this = sys.modules[__name__]
-
-# configure logger
-logging.basicConfig(level=LOGLEVEL)
-logger = logging.getLogger(__name__)
-
 
 # Ensure all mandatory environment variables are set, otherwise exit
 if None in [

--- a/apps/slackbot/prompt.py
+++ b/apps/slackbot/prompt.py
@@ -21,7 +21,7 @@ class SlackBotPrompt(BaseChatPromptTemplate, BaseModel):
     def construct_base_prompt(self):
         full_prompt = f"You are a friendly assistent bot called {self.ai_name}\n\n"
         full_prompt += f"\n\n{get_prompt(self.tools)}"
-
+        logger.debug(full_prompt)
         return full_prompt
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
@@ -46,12 +46,15 @@ class SlackBotPrompt(BaseChatPromptTemplate, BaseModel):
             historical_messages = [message] + historical_messages
             used_tokens += message_tokens
 
+        logger.debug(input_message)
         input_message = HumanMessage(content=input_message)
 
         messages: List[BaseMessage] = [base_prompt, time_prompt]
         messages += historical_messages
         messages.append(input_message)
-        logger.debug("all_prompt:", messages)
+        logger.debug(f"Base prompt: {base_prompt}")
+        logger.debug(f"Time prompt: {time_prompt}")
+        logger.debug(f"Historical messages: {historical_messages}")
         return messages
 
     def process_chat_history(self, messages: List[dict]) -> List[BaseMessage]:

--- a/apps/slackbot/prompt.py
+++ b/apps/slackbot/prompt.py
@@ -1,4 +1,4 @@
-import logging
+from loguru import logger
 import time
 from typing import Any, Callable, List
 
@@ -9,8 +9,6 @@ from pydantic import BaseModel
 
 from prompt_generator import get_prompt
 from tools import BaseTool
-
-logger = logging.getLogger(__name__)
 
 
 class SlackBotPrompt(BaseChatPromptTemplate, BaseModel):

--- a/apps/slackbot/requirements.txt
+++ b/apps/slackbot/requirements.txt
@@ -14,3 +14,4 @@ pinecone-client
 Flask-Cors==3.0.10
 beautifulsoup4==4.12.2
 markdown~=3.4.4         # Required by unstructured/partition/md.py
+loguru~=0.7.0

--- a/apps/slackbot/scrape/extract_github_readme.py
+++ b/apps/slackbot/scrape/extract_github_readme.py
@@ -1,5 +1,5 @@
 import base64
-import logging
+from loguru import logger
 import re
 
 import pinecone
@@ -10,7 +10,6 @@ from langchain.embeddings.openai import OpenAIEmbeddings
 import config as cfg
 from vectorstores import ConversationStore
 
-logger = logging.getLogger(__name__)
 
 
 def get_owner_and_repo(url):

--- a/apps/slackbot/task_agent.py
+++ b/apps/slackbot/task_agent.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from loguru import logger
 from os import environ
 from typing import List, Optional
 
@@ -17,8 +17,6 @@ from action_planner import SelectiveActionPlanner
 from action_planner.base import BaseActionPlanner
 from output_parser import BaseTaskOutputParser, TaskOutputParser
 from post_processors import md_link_to_slack
-
-logger = logging.getLogger(__name__)
 
 
 class TaskAgent:

--- a/apps/slackbot/tools.py
+++ b/apps/slackbot/tools.py
@@ -1,5 +1,5 @@
-import logging
 import os
+from loguru import logger
 from typing import Any
 
 import requests
@@ -12,8 +12,6 @@ from langchain.vectorstores.base import VectorStoreRetriever
 from typing_extensions import Literal
 
 import config as cfg
-
-logger = logging.getLogger(__name__)
 
 
 def get_tools(memory):

--- a/apps/slackbot/utils.py
+++ b/apps/slackbot/utils.py
@@ -1,4 +1,4 @@
-import logging
+from loguru import logger
 import re
 from typing import List
 from urllib.parse import urlparse
@@ -11,7 +11,6 @@ from langchain.document_loaders import UnstructuredMarkdownLoader, UnstructuredP
 from langchain.llms import OpenAI
 from langchain.text_splitter import TokenTextSplitter
 
-logger = logging.getLogger(__name__)
 
 
 def load_files(files: List[str]) -> List[Document]:

--- a/apps/slackbot/vectorstores.py
+++ b/apps/slackbot/vectorstores.py
@@ -1,4 +1,4 @@
-import logging
+from loguru import logger
 import os
 import uuid
 from typing import Any, Iterable, List, Optional, Tuple, Type
@@ -15,7 +15,6 @@ from langchain.vectorstores.base import VectorStore, VectorStoreRetriever
 import config as cfg
 from utils import load_files
 
-logger = logging.getLogger(__name__)
 
 
 class ConversationStore(VectorStore):

--- a/scripts/Pinecone.ipynb
+++ b/scripts/Pinecone.ipynb
@@ -223,7 +223,7 @@
         "import uuid\n",
         "from typing import Any, Iterable, List, Optional, Type\n",
         "from langchain.docstore.document import Document\n",
-        "import logging\n",
+        "from loguru import logger\n",
         "from langchain.vectorstores.base import VectorStoreRetriever"
       ]
     },
@@ -1410,7 +1410,7 @@
         "import uuid\n",
         "from typing import Any, Iterable, List, Optional, Type\n",
         "from langchain.docstore.document import Document\n",
-        "import logging\n",
+        "from loguru import logger\n",
         "from langchain.vectorstores.base import VectorStoreRetriever\n",
         "\n",
         "PINECONE_API_KEY = os.environ.get(\"PINECONE_API_KEY\")\n",


### PR DESCRIPTION
Instructions:
```
  cd apps/slackbot
  pip install -r requirements.txt
  python bolt_app.py
```

Why switch loggers?

1. Loguru's colorized log output is easier to read than Python's standard logger output.

2. Loguru formats objects using modern Python string formatting, instead of the older `%s` formatting available in the standard logger. Because of this, it's able to log more of our objects, instead of raising exceptions or just emitting blank lines like the standard logger does.

3. Loguru also supports JSON serialization, which can be useful in production if we want a structured log format instead of strings.

Read more here: https://loguru.readthedocs.io/en/stable/