### PR TITLE
updating some docs referencing the old docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,15 @@
 # SHERPA - THINKING COMPANION
 
-**To see the documentation, visit: https://llm-live-book.readthedocs.io/**
+To see the documentation, visit: https://sherpa-ai.readthedocs.io/
 
-# Contributions Guideline
+## Contributions Guideline
 
-## Making Changes through Pull Requests
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it’s:
 
-To make changes to this project, you will need to fork the repository to your own GitHub account, make the changes to your forked repository, and then submit a pull request to our main repository. Here are the steps:
+- Reporting a bug
+- Discussing the current state of the book or the accompanying software
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
 
-1. Fork the repository to your own GitHub account by clicking the "Fork" button on the top right of the repository page.
-2. Clone the forked repository to your local machine by running the following command in your terminal: `git clone https://github.com/your-username/repo-name.git`
-3. Create a new branch for your changes by running the following command: `git checkout -b your-branch-name`
-4. Make the desired changes to the book.
-5. Commit your changes with a descriptive commit message by running the following command:`git commit -m "your commit message"`
-6. Push your changes to your forked repository by running the following command: `git push origin your-branch-name`
-7. Go to the main repository and submit a pull request with a description of your changes.
-
-Once your pull request is submitted, it will be reviewed by our team and either merged or commented on for further changes.
-
-NOTE: If the change you are considering is fairly major, please suggest it as an issue first so that we can coordinate before you put in the effort.
-
-## Suggesting Changes through Issues
-
-If you would like to suggest changes to the book without making direct changes, you can create an issue in our repository. Here are the steps:
-
-1. Go to the repository and click on the "Issues" tab.
-2. Click on the "New Issue" button.
-3. Provide a descriptive title and description of your suggested change.
-4. Optionally, you can label your issue to make it easier to categorize.
-5. Submit the issue.
-
-Our team will review the issue and either implement the suggested change or respond with feedback.
+To get started, visit: https://sherpa-ai.readthedocs.io/en/latest/How_To/Contribute/contribute.html

--- a/apps/slackbot/README.md
+++ b/apps/slackbot/README.md
@@ -1,1 +1,1 @@
-**To see the documentation, visit: https://llm-live-book.readthedocs.io/**
+**To see the documentation, visit: https://sherpa-ai.readthedocs.io/**

--- a/apps/slackbot/tests/test_post_processor.py
+++ b/apps/slackbot/tests/test_post_processor.py
@@ -16,22 +16,22 @@ def test_slack_link() -> None:
         "even exhibit a rudimentary understanding of language. The emergent behavior"
         " of large language models is a result of the complex dynamics and rich "
         "interactions within the model architecture. "
-        "[source](https://llm-live-book.readthedocs.io/en/latest/KnowledgeOps/rise_of_agents.html)"
+        "[source](https://sherpa-ai.readthedocs.io/en/latest/KnowledgeOps/rise_of_agents.html)"
     )
 
     result = md_link_to_slack(test)
     assert (
-        "<https://llm-live-book.readthedocs.io/en/latest/KnowledgeOps/rise_of_agents.html|source>"
+        "<https://sherpa-ai.readthedocs.io/en/latest/KnowledgeOps/rise_of_agents.html|source>"
         in result
     )
 
 
 def test_slack_link_nested() -> None:
     """Test that the Slack links are converted correctly."""
-    test = "[^1^]: [LLamaIndex Documentation](https://llm-live-book.readthedocs.io/en/latest/LLM%20Agents/llm_tools_use.html)"
+    test = "[^1^]: [LLamaIndex Documentation](https://sherpa-ai.readthedocs.io/en/latest/LLM%20Agents/llm_tools_use.html)"
 
     result = md_link_to_slack(test)
     assert (
         result
-        == "[^1^]: <https://llm-live-book.readthedocs.io/en/latest/LLM%20Agents/llm_tools_use.html|LLamaIndex Documentation>"
+        == "[^1^]: <https://sherpa-ai.readthedocs.io/en/latest/LLM%20Agents/llm_tools_use.html|LLamaIndex Documentation>"
     )

--- a/docs/How_To/Contribute/contribute.rst
+++ b/docs/How_To/Contribute/contribute.rst
@@ -1,5 +1,5 @@
-Contribute
-==========
+Contribute via GitHub
+=====================
 
 We love your input! We want to make contributing to this project as easy
 and transparent as possible, whether it’s:

--- a/docs/How_To/Slack Bot/1_slackbot_workspace.rst
+++ b/docs/How_To/Slack Bot/1_slackbot_workspace.rst
@@ -1,12 +1,13 @@
-Set up Sherpa SlackBot in your Own Workspace
-========================================
+Set up Sherpa Slackbot in your Own Workspace
+============================================
+
 This tutorial describes how to run the Sherpa SlackBot in your own Slack Workspace. 
 We will start by installing the dependencies necessary for the SlackBot. Then we will create a 
 Slack APP by in a new workspace. Finally, we will connect the SlackBot to the Sherpa backend
 so that you can talk to the SlackBot. 
 
 Install Slack App
-**********************
+*****************
 
 In order to make it easier to test the Slack APP, we will create a test Slack Workspace. Skip this step if you already have a Slack Workspace that you can play with. 
 
@@ -146,6 +147,7 @@ Now we are all set! You can type any message and add `@Sherpa` (or the name of y
 Have fun! And please join our `slack channel <https://aisc-to.slack.com/ssb/redirect>`__ if you are interested in contributing to this project!
 
 Further Reading
-****************************
+***************
+
 * `Slack API <https://api.slack.com/>`__
 * `SlackBot <https://github.com/Aggregate-Intellect/sherpa/tree/main/apps/slackbot>`__

--- a/docs/How_To/Slack Bot/2_run_slackbot.rst
+++ b/docs/How_To/Slack Bot/2_run_slackbot.rst
@@ -179,7 +179,7 @@ and `Flask: Debugging Application Errors <https://flask.palletsprojects.com/en/2
 
 
 Reference
-=========
+~~~~~~~~~
 
 Once you have the chatbot running you can start interacting with it by mentioning the app in a Slack 
 channel. See :doc:`Talk to Sherpa <0_slack_bot_intro>` for how to do this.

--- a/docs/How_To/index.rst
+++ b/docs/How_To/index.rst
@@ -9,15 +9,10 @@ Contribution Guidelines
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 There are many ways you can contribute to the Sherpa project. 
-Check out the contribution guidelines link below to learn more. Following these guidelines ensure that we maintain a 
-healthy and inclusive community. If you have any feedback on how these guidelines can be modified 
-to improve our efficiency and inclusivity, please reach out through the communication channel 
+Check out the :doc:`contribution guidelines <Contribute/contribute>` to learn more. 
+Following these guidelines ensure that we maintain a healthy and inclusive community. 
+If you have any feedback on how these guidelines can be modified to improve our efficiency and inclusivity, please reach out through the communication channel 
 outlines below.
-
-.. toctree::
-    :maxdepth: 1
-
-    Contribute/contribute.rst
 
 
 Communication Channels
@@ -34,31 +29,32 @@ Development Environment Setup:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 These pages provide detailed instructions on how to set up the development environment
 so that you can follow along with the code, run Sherpa in your own Slack workspace, and 
-contribute changes to Sherpa and the LLM Live Book.
+contribute changes to Sherpa.
 
 .. toctree::
     :maxdepth: 1
     :glob:
 
+    Contribute/*
     Slack Bot/*
 
 Codebase Overview:
 ^^^^^^^^^^^^^^^^^^
-[] TO DO
+[ ] TO DO
 
 - Offer a high-level tour of the codebase to familiarize the new developer with the project's structure.
 - Point out essential directories, modules, and key components.
 
 Starter Tasks:
 ^^^^^^^^^^^^^^
-[] TO DO
+[ ] TO DO
 
 - Suggest beginner-friendly tasks that new contributors can work on to get started.
 - Provide links to any "good first issues" or "beginner-friendly" labels in the issue tracker.
 
 Mentoring/Buddy System:
 ^^^^^^^^^^^^^^^^^^^^^^^
-[] TO DO
+[ ] TO DO
 
 - Offer to pair new contributors with an experienced contributor (mentor/buddy) who can guide them through their first contributions.
 - Explain how newcomers can reach out to a mentor if interested.
@@ -72,19 +68,19 @@ Community Events:
 
 Recognition and Attribution:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-[] TO DO
+[ ] TO DO
 
 - Explain how the project recognizes and attributes contributions, such as through contributor badges, hall of fame, etc.
 
 Feedback and Questions:
 ^^^^^^^^^^^^^^^^^^^^^^^
-[] TO DO
+[ ] TO DO
 
 - Encourage the new developer to ask questions and seek help whenever needed.
 - Provide contact details of community managers or project leaders for further assistance.
 
 
-Thank you for joining our open-source community! We believe that your contributions will make a valuable impact on our LLM Live Book Project. If you have any questions or need assistance during the onboarding process, please don't hesitate to reach out to me.
+Thank you for joining our open-source community! We believe that your contributions will make a valuable impact on our Sherpa - Thinking Companion Project. If you have any questions or need assistance during the onboarding process, please don't hesitate to reach out to me.
 
 Happy coding!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'LLM Live Book'
+project = 'Sherpa - Thinking Companion'
 copyright = '2023, Amir Feizpour et al'
 author = 'Amir Feizpour et al'
 
@@ -58,7 +58,7 @@ html_theme_options = {
     "show_toc_level": 3,
     "toc_title": "In This Page:",
 }
-html_title = "LLM Live Book"
+html_title = "Sherpa - Thinking Companion"
 html_logo = "Open Book/cover_image.png"
 html_favicon = ""
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,6 @@ Project Overview:
    :caption: EXPLORE
    :maxdepth: 2
 
-   About Sherpa <About_Sherpa/index>
    How To <How_To/index>
    LLM Open Book <Open Book/index>
+   About Sherpa <About_Sherpa/index>


### PR DESCRIPTION
@20001LastOrder some of the files we have in `/app` hardcoded references to the library URL which is now moved to https://sherpa-ai.readthedocs.io/

I did a Find & Replace but I'm not sure what the relevance of those hardcoded URLs is. so can you review this PR, and make any changes necessary for those, and if everything looks good merge?

@ChenKua once this is merged, then we should update all the material related to the open book content in the vector database given the new URL above