### PR TITLE
add youtube link in How_To docs

### DIFF
--- a/docs/How_To/Slack Bot/1_slackbot_workspace.rst
+++ b/docs/How_To/Slack Bot/1_slackbot_workspace.rst
@@ -6,6 +6,11 @@ We will start by installing the dependencies necessary for the SlackBot. Then we
 Slack APP by in a new workspace. Finally, we will connect the SlackBot to the Sherpa backend
 so that you can talk to the SlackBot. 
 
+Video tutorial
+***************
+https://youtu.be/HX4lxzBkEoQ?si=6NlQupyZPrM3MHr1
+
+
 Install Slack App
 *****************
 

--- a/docs/How_To/Slack Bot/2_run_slackbot.rst
+++ b/docs/How_To/Slack Bot/2_run_slackbot.rst
@@ -8,6 +8,10 @@ text processing tasks. While you can :doc:`talk to Sherpa in the AISC Slack work
 if you want to go deeper and contribute to code or run Sherpa in your own Slack workspace then 
 this section is for you.
 
+Video tutorial
+--------------
+https://youtu.be/HX4lxzBkEoQ?si=6NlQupyZPrM3MHr1
+
 Slackbot Features
 -----------------
 


### PR DESCRIPTION
I added the video tutorial link in these files:
`docs\How_To\Slack Bot\1_slackbot_workspace.rst`
`docs\How_To\Slack Bot\2_run_slackbot.rst`