### PR TITLE
Fix slackbot installation with venv instructions

### DIFF
--- a/docs/How_To/Slack Bot/2_run_slackbot.rst
+++ b/docs/How_To/Slack Bot/2_run_slackbot.rst
@@ -88,18 +88,18 @@ Run with Virtual Environment
 
 5. Install the dependencies of the slackbot: 
    
-   * Install dependency with `Poetry <https://python-poetry.org/>`__ (recommended, this will give you the ability to edit the code in `sherpa_ai` without rebuild) 
+   * Install dependencies with `Poetry <https://python-poetry.org/>`__ (recommended, this will give you the ability to edit the code in `sherpa_ai` without rebuild) 
 
       .. code:: bash
 
-         cd src/apps/slackapp
+         cd src
          poetry install
 
      Followed by:
 
       .. code:: bash
 
-         cd ../..
+         cd apps/slackapp
          poetry install
 
    * Install dependency with `pip <https://pip.pypa.io/en/stable/>`__

--- a/docs/How_To/Slack Bot/2_run_slackbot.rst
+++ b/docs/How_To/Slack Bot/2_run_slackbot.rst
@@ -86,7 +86,7 @@ Run with Virtual Environment
 
        conda activate slackbot
 
-5. Install the dependencies of the slackbote: 
+5. Install the dependencies of the slackbot: 
    
    * Install dependency with `Poetry <https://python-poetry.org/>`__ (recommended, this will give you the ability to edit the code in `sherpa_ai` without rebuild) 
 
@@ -94,7 +94,14 @@ Run with Virtual Environment
 
          cd src/apps/slackapp
          poetry install
-      
+
+     Followed by:
+
+      .. code:: bash
+
+         cd ../..
+         poetry install
+
    * Install dependency with `pip <https://pip.pypa.io/en/stable/>`__
 
       .. code:: bash


### PR DESCRIPTION
# Your checklist for this pull request
Thank you for submitting a pull request! To speed up the review process, please follow this checklist:

- [X] My Pull Request is small and focused on one topic so it can be reviewed easily 
- [N/A] My code follows the style guidelines of this project (`make format`)
- [X] Commit messages are detailed
- [X] I have performed a self-review of my code
- [N/A] I commented hard-to-understand parts of my code
- [X] I updated the documentation (docstrings, `/docs`)
- [X] My changes generate no new warnings (or explain any new warnings and why they're ok)
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] All tests pass when I run `pytest tests` (offline mode)

Additional steps for code with networking dependencies:

- [N/A] I followed the [offline and online testing guidelines](https://sherpa-ai.readthedocs.io/en/latest/How_To/Test/test.html#offline-and-online-testing)
- [N/A] All tests pass when I run `pytest tests --external_api` (online mode, making network calls)

# Description
Update docs for Run and Develop Sherpa Slackbot -> Usage -> Run with Virtual Environment -> step 5 to add a step to perform `poetry install` from the `pyroject.toml` file in the parent `src` directory as well. I also corrected a small typo. (I hope that's okay).

The Slack app has a dependency on sherpa-ai and even though sherpa-ai is included in the `pyproject.toml` file under `src/app/slackapp`, this does *not* mean Poetry will automatically install sherpa-ai's dependencies as well, which will result in errors if you are just trying to run/test Sherpa Slackbot.