### PR TITLE
Add how to install spaCy pipeline with Poetry to docs

### DIFF
--- a/docs/How_To/Slack Bot/2_run_slackbot.rst
+++ b/docs/How_To/Slack Bot/2_run_slackbot.rst
@@ -102,7 +102,7 @@ Run with Virtual Environment
          cd apps/slackapp
          poetry install
 
-   * Install dependency with `pip <https://pip.pypa.io/en/stable/>`__
+   * Install dependencies with `pip <https://pip.pypa.io/en/stable/>`__
 
       .. code:: bash
 
@@ -111,7 +111,15 @@ Run with Virtual Environment
 
 6. Download the spaCy trained pipeline for English.
 
-    .. code:: bash
+   * If you installed dependencies with Poetry in the previous step, run:
+
+      .. code:: bash
+
+        poetry run python -m spacy download en_core_web_sm
+
+   * If you installed dependencies with pip, run:
+
+      .. code:: bash
 
         python -m spacy download en_core_web_sm
 


### PR DESCRIPTION
# Your checklist for this pull request
Thank you for submitting a pull request! To speed up the review process, please follow this checklist:

- [x] My Pull Request is small and focused on one topic so it can be reviewed easily 
- [x] My code follows the style guidelines of this project (`make format`)
- [x] Commit messages are detailed
- [x] I have performed a self-review of my code
- [x] I commented hard-to-understand parts of my code
- [x] I updated the documentation (docstrings, `/docs`)
- [x] My changes generate no new warnings (or explain any new warnings and why they're ok)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass when I run `pytest tests` (offline mode)

# Description
This is a minor addition to the documentation that was left out of PR #333 (See comments under that PR).

Add instructions on how to install the spaCy trained pipelines for EN if you are using Poetry for dependency management.
Closes #332 (It was already closed, but this was overlooked and left out).