### PR TITLE
Fix github action failing

### DIFF
--- a/.github/workflows/offline_tests.yml
+++ b/.github/workflows/offline_tests.yml
@@ -21,7 +21,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry
           cd src
-          poetry config virtualenvs.create false
           poetry install
       
       # en_core_web_sm required by spacy needs to be installed separately


### PR DESCRIPTION
# Description

Recently, automated tests in GitHub pull requests have started failing with the following error:

![image](https://github.com/Aggregate-Intellect/sherpa/assets/25534730/c43cd007-13da-4ebc-9c04-966e3ce785ee)


After some investigation, I believe this is the fact that we installed dependencies in the same environment as we installed Sherpa due to the following line in the GitHub Action file:

`poetry config virtualenvs.create false`

According to the following issue raised in the poetry repo:

https://github.com/python-poetry/poetry/issues/9351