### PR TITLE
Fix ReadTheDocs.io build break

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx-book-theme
 sphinx-design
--e ../src  # local dependency with editable install


### PR DESCRIPTION
ReadTheDocs build breaks on this line which I recently added to docs/requirements.txt:

```
-e ../src  # local dependency with editable install
```

I believe removing this line will fix the build. I don't know of a way to test readthedocs.io build
process locally, so I guess we should just push this and see what happens.

# Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

# Checklists
To speed up the review process, please follow these checklists:

## Development
- [x] The Pull Request is small and focused on one topic
- [ ] Lint rules pass locally (`make format && make lint`)
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development (`make test`)
- [ ] The changes generate no new warnings (or explain any new warnings and why they're ok)
- [ ] Commit messages are detailed
- [ ] Changed code is self-explanatory and/or I added comments
- [ ] I updated the documentation (docstrings, /docs)
See the testing guidelines for help on tests, especially those involving web services.

## Code review
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] I have performed a self-review of my code
- [ ] Issue from task tracker has a link to this pull request

💔 Thank you for submitting a pull request!