### PR TITLE
Add support for action dependency through args

### DIFF
--- a/src/sherpa_ai/actions/base.py
+++ b/src/sherpa_ai/actions/base.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -25,34 +25,133 @@ class ActionResource(BaseModel):
     content: str
 
 
+class ActionArgument(BaseModel):
+    """
+    Argument used for an action.
+
+    Attributes:
+        name (str): Name of the argument.
+        type (str): Type of the argument. (default: "str")
+        description (str): Description of the argument. (default: "")
+        source (str): source of the argument, select from (agent, belief)
+            If source is agent, the argument is provided by the agent (LLM).
+            If source is belief, the value of the argument is retrieved from the
+            dictionary of the belief. (default: "agent")
+        key (str): key of the argument in the belief dictionary if source is belief.
+            (default: name of the argument, if source is belief)
+    """
+
+    name: str
+    type: str = "str"
+    description: str = ""
+    source: str = "agent"
+    key: Optional[str] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.source == "belief" and not self.key:
+            self.key = self.name
+
+
 class BaseAction(ABC, BaseModel):
+    """
+    Base class for an action.
+
+    Attributes:
+        name (str): Name of the action.
+        args (Union[dict, list[ActionArgument]]): Arguments required to run the action.
+        usage (str): Usage description of the action.
+        belief (Any): Belief used for the action. It is required if any argument
+            requires belief. (default: None)
+        output_key (Optional[str]): Output key of the action. (default: name of the
+            action)
+    """
+
     class Config:
         arbitrary_types_allowed = True
 
     name: str
-    args: dict
+    args: Union[dict, list[ActionArgument]]
     usage: str
     belief: Any = None
+    output_key: Optional[str] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._process_arguments()
+
+        if self.output_key is None:
+            self.output_key = self.name
+
+    def _process_arguments(self):
+        """
+        Process the arguments for the action. Converting the arguments to list of
+        ActionArgument if it is a dict. Check if belief is provided if any argument
+        require belief.
+        """
+        if isinstance(self.args, dict):
+            # convert dict to list of ActionArgument
+            arguments = []
+            for arg_name, arg_value in self.args.items():
+                if isinstance(arg_value, str):
+                    arg_value = {"type": arg_value}
+                arg_value["name"] = arg_name
+                arguments.append(ActionArgument(**arg_value))
+            self.args = arguments
+
+        require_belief = False
+        for arg in self.args:
+            if arg.source == "belief":
+                require_belief = True
+                break
+
+        if require_belief and not self.belief:
+            raise ValueError(
+                f"Action {self.name} requires belief but no belief is provided"
+            )
 
     @abstractmethod
     def execute(self, **kwargs):
         pass
 
     def __call__(self, **kwargs):
+        # Retrieve the arguments from the belief or agent
         filtered_kwargs = {}
         for arg in self.args:
-            if arg not in kwargs:
-                raise ValueError(f"Missing argument: {arg}")
-            filtered_kwargs[arg] = kwargs[arg]
+            if arg.source == "agent":
+                if arg.name not in kwargs:
+                    raise ValueError(f"Missing argument from input: {arg.name}")
+                filtered_kwargs[arg.name] = kwargs[arg.name]
+            elif arg.source == "belief":
+                if not self.belief.has(arg.key):
+                    raise ValueError(f"Missing argument in belief: {arg.name}")
+                filtered_kwargs[arg.name] = self.belief.get(arg.key)
+            else:
+                raise ValueError(
+                    f"Invalid source: {arg.source}, the available sources "
+                    "are 'agent' and 'belief'"
+                )
 
+        # Execute the action
         result = self.execute(**filtered_kwargs)
+
+        # Save the result to the belief
         self.belief: Belief = self.belief
         if self.belief:
-            self.belief.set(self.name, result)
+            self.belief.set(self.output_key, result)
         return result
 
     def __str__(self):
-        tool_desc = {"name": self.name, "args": self.args, "usage": self.usage}
+        arguments = {}
+
+        for arg in self.args:
+            if arg.source != "agent":
+                continue
+            arguments[arg.name] = (
+                arg.type if arg.description == "" else f"{arg.type}, {arg.description}"
+            )
+
+        tool_desc = {"name": self.name, "args": arguments, "usage": self.usage}
 
         return json.dumps(tool_desc, indent=4)
 

--- a/src/tests/unit_tests/actions/test_action_dependency.py
+++ b/src/tests/unit_tests/actions/test_action_dependency.py
@@ -1,0 +1,154 @@
+# Tests for the dependency handling of action arguments in the BaseAction
+
+from sherpa_ai.actions.base import BaseAction
+from sherpa_ai.memory import Belief
+
+
+class MockAction(BaseAction):
+    name: str = "mock_action"
+    usage: str = "Mock action for testing"
+    arg_value_dict: dict
+
+    def execute(self, **kwargs) -> str:
+        for key, value in self.arg_value_dict.items():
+            assert kwargs[key] == value
+
+        return "success"
+
+
+def test_args_from_belief():
+    belief = Belief()
+    belief.set("test_arg", "test_value")
+    action = MockAction(
+        args={"test_arg": {"type": "str", "source": "belief"}},
+        belief=belief,
+        arg_value_dict={"test_arg": "test_value"},
+    )
+
+    action()
+
+
+def test_args_from_belief_and_agent():
+    belief = Belief()
+    belief.set("test_arg", "test_value")
+    action = MockAction(
+        args={
+            "test_arg": {"type": "str", "source": "belief"},
+            "test_arg2": {"type": "str", "source": "agent"},
+        },
+        belief=belief,
+        arg_value_dict={"test_arg": "test_value", "test_arg2": "test_value2"},
+    )
+
+    action(test_arg2="test_value2")
+
+
+def test_args_from_belief_key():
+    belief = Belief()
+    belief.set("arg1", "test_value")
+    action = MockAction(
+        args={
+            "test_arg": {"type": "str", "source": "belief", "key": "arg1"},
+            "test_arg2": {"type": "str", "source": "agent"},
+        },
+        belief=belief,
+        arg_value_dict={"test_arg": "test_value", "test_arg2": "test_value2"},
+    )
+
+    action(test_arg2="test_value2")
+
+
+def test_store_action_result():
+    belief = Belief()
+    action = MockAction(
+        name="mock_action",
+        args={},
+        belief=belief,
+        arg_value_dict={},
+    )
+
+    action()
+    assert belief.get("mock_action") == "success"
+
+
+def test_store_action_result_with_key():
+    belief = Belief()
+    action = MockAction(
+        args={},
+        belief=belief,
+        arg_value_dict={},
+        output_key="output_key",
+    )
+
+    action()
+    assert belief.get("output_key") == "success"
+
+
+def test_missing_argument_belief():
+    belief = Belief()
+    action = MockAction(
+        args={"test_arg": {"type": "str", "source": "belief"}},
+        belief=belief,
+        arg_value_dict={},
+    )
+
+    try:
+        action()
+    except ValueError as e:
+        assert str(e) == "Missing argument in belief: test_arg"
+
+
+def test_missing_argument_agent():
+    belief = Belief()
+    action = MockAction(
+        args={"test_arg": {"type": "str", "source": "agent"}},
+        belief=belief,
+        arg_value_dict={},
+    )
+
+    try:
+        action()
+    except ValueError as e:
+        assert str(e) == "Missing argument from input: test_arg"
+
+
+def test_action_to_string():
+    belief = Belief()
+    action = MockAction(
+        args={
+            "test_arg1": {"type": "str", "source": "belief"},
+            "test_arg2": {"type": "str", "source": "agent"},
+        },
+        belief=belief,
+        arg_value_dict={"test_arg1": "test_value", "test_arg2": "test_value2"},
+    )
+
+    action_string = str(action)
+
+    assert "test_arg2" in action_string
+    assert "test_arg1" not in action_string
+
+
+def test_action_sequence():
+    belief = Belief()
+    belief.set("test_arg", "test_value")
+
+    action1 = MockAction(
+        args={"test_arg": {"type": "str", "source": "belief"}},
+        belief=belief,
+        arg_value_dict={"test_arg": "test_value"},
+        output_key="out1",
+    )
+
+    action2 = MockAction(
+        args={"test_arg": {"type": "str", "source": "belief", "key": "out1"}},
+        belief=belief,
+        arg_value_dict={"test_arg": "success"},
+        output_key="out2",
+    )
+
+    action1()
+    action2()
+
+    assert belief.get("out1") == "success"
+    assert belief.get("out2") == "success"


### PR DESCRIPTION
# Description
Add support for dependencies of actions through the arguments. It includes:
1. Configure `source`, `description` and `key` of action arguments
2. Store action results in the belief, optionally with a named output key
3. Modify the `__str__` value such that it only includes actions from the agent by default
4. Add tests for all these features

Action arguments are defined using JSON format but later translated into ActionArgument for strictly defined schema

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

# Checklists
To speed up the review process, please follow these checklists:

## Development
- [x] The Pull Request is small and focused on one topic
- [x] Lint rules pass locally (`make format && make lint`)
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development (`make test`)
- [x] The changes generate no new warnings (or explain any new warnings and why they're ok)
- [x] Commit messages are detailed
- [x] Changed code is self-explanatory and/or I added comments
- [x] I updated the documentation (docstrings, /docs)
See the testing guidelines for help on tests, especially those involving web services.

## Code review
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] I have performed a self-review of my code
- [ ] Issue from task tracker has a link to this pull request

💔 Thank you for submitting a pull request!