### PR TITLE
Add support for other callbacks: on_exit, before, on_enter, after

### DIFF
--- a/src/sherpa_ai/actions/base.py
+++ b/src/sherpa_ai/actions/base.py
@@ -93,7 +93,7 @@ class BaseAction(ABC, BaseModel):
             arguments = []
             for arg_name, arg_value in self.args.items():
                 if isinstance(arg_value, str):
-                    arg_value = {"type": arg_value}
+                    arg_value = {"description": arg_value}
                 arg_value["name"] = arg_name
                 arguments.append(ActionArgument(**arg_value))
             self.args = arguments

--- a/src/sherpa_ai/agents/base.py
+++ b/src/sherpa_ai/agents/base.py
@@ -355,7 +355,7 @@ class BaseAgent(ABC, BaseModel):
         try:
             action_output = await action(**inputs)
             return action_output
-        except Exception as e:
+        except SherpaActionExecutionException as e:
             self.belief.update_internal(
                 EventType.action_output,
                 self.feedback_agent_name,
@@ -363,3 +363,6 @@ class BaseAgent(ABC, BaseModel):
             )
             logger.exception(e)
             return None
+        except Exception as e:
+            logger.exception(e)
+            return e

--- a/src/sherpa_ai/memory/state_machine.py
+++ b/src/sherpa_ai/memory/state_machine.py
@@ -7,8 +7,7 @@ from transitions.extensions.states import Tags, add_state_features
 
 from sherpa_ai.actions.base import BaseAction
 from sherpa_ai.actions.dynamic import AsyncDynamicAction, DynamicAction
-from sherpa_ai.memory.utils import (StateDesc, TransitionDesc,
-                                    add_transition_features)
+from sherpa_ai.memory.utils import StateDesc, TransitionDesc, add_transition_features
 
 
 class State(ts.State):
@@ -239,18 +238,20 @@ class SherpaStateMachine:
             if isinstance(action, BaseAction):
                 _ = str(action)
 
-            for arg in action.args:
-                if type(arg) is str:
-                    arg_usage = action.args[arg]
-                else:
-                    arg_usage = arg.description
-                    arg = arg.name
+                for arg in action.args:
+                    if type(arg) is str:
+                        arg_usage = action.args[arg]
+                    else:
+                        arg_usage = arg.description
+                        arg = arg.name
 
-                if arg in args:
-                    logger.warning(f"Duplicate argument {arg} in action {action.name}")
-                args[arg] = arg_usage
+                    if arg in args:
+                        logger.warning(
+                            f"Duplicate argument {arg} in action {action.name}"
+                        )
+                    args[arg] = arg_usage
 
-            description += f". Next, {action.usage}"
+                description += f". Next, {action.usage}"
 
         return args, description
 


### PR DESCRIPTION
# Description
Add support for other callbacks when a transition happens on_exit, before, on_enter, and after. These just need to be added in the corresponding state / transition definitions and the LLM will be able to see the `usage` information and provide `args` for these callbacks

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
