### PR TITLE
Add support for markdown in documentation

### DIFF
--- a/docs/How_To/tutorials.rst
+++ b/docs/How_To/tutorials.rst
@@ -10,3 +10,4 @@ The tutorials are a hands-on way for software developers to learn about Sherpa's
     Tutorials/document_reader
     Tutorials/add_citation
     Tutorials/search_refinement
+    Tutorials/state_management

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -73,3 +74,18 @@ html_favicon = ""
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+# Extensions for various markdown elements support
+myst_enable_extensions = [
+    "amsmath",
+    "dollarmath",
+    "html_admonition",
+    # "colon_fence",
+    # "deflist",
+    # "html_image",
+    # "linkify",
+    # "replacements",
+    # "smartquotes",
+    # "substitution"
+]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-book-theme
 sphinx-design
+myst-parser


### PR DESCRIPTION
# Description
As described in the title. Markdown files are now treated the same as rst files when building documentation.

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
