### PR TITLE
Add functionality to put task result status for agent run

### DIFF
--- a/src/sherpa_ai/actions/exceptions.py
+++ b/src/sherpa_ai/actions/exceptions.py
@@ -6,3 +6,10 @@ class SherpaActionExecutionException(Exception):
         super().__init__(message)
         self.message = message
         self.stacktrace = traceback.format_stack()
+
+
+class SherpaMissingInformationException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+        self.stacktrace = traceback.format_stack()

--- a/src/sherpa_ai/config/task_result.py
+++ b/src/sherpa_ai/config/task_result.py
@@ -1,0 +1,8 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class TaskResult(BaseModel):
+    content: str
+    status: Literal["success", "failed", "waiting"] = "success"

--- a/src/sherpa_ai/policies/react_sm_policy.py
+++ b/src/sherpa_ai/policies/react_sm_policy.py
@@ -8,7 +8,8 @@ from loguru import logger
 from sherpa_ai.actions.base import BaseAction
 from sherpa_ai.policies.base import BasePolicy, PolicyOutput
 from sherpa_ai.policies.exceptions import SherpaPolicyException
-from sherpa_ai.policies.utils import is_selection_trivial, transform_json_output
+from sherpa_ai.policies.utils import (is_selection_trivial,
+                                      transform_json_output)
 
 if TYPE_CHECKING:
     from sherpa_ai.memory.belief import Belief

--- a/src/tests/integration_tests/test_feedback_policy_in_qa.py
+++ b/src/tests/integration_tests/test_feedback_policy_in_qa.py
@@ -61,7 +61,7 @@ def test_feedback_policy_in_qa_incomplete(get_llm, mock_google_search):
 
     result = qa_agent.run()
 
-    assert "Jupiter" in result
+    assert "Jupiter" in result.content
 
 
 def test_feedback_policy_in_qa_complete(get_llm, mock_google_search):
@@ -97,4 +97,4 @@ def test_feedback_policy_in_qa_complete(get_llm, mock_google_search):
 
     result = qa_agent.run()
 
-    assert "Jupiter" in result
+    assert "Jupiter" in result.content

--- a/src/tests/unit_tests/agents/test_qa_agent.py
+++ b/src/tests/unit_tests/agents/test_qa_agent.py
@@ -53,7 +53,7 @@ def test_qa_agent_policy_selection_exception():
 
     result = agent.run()
 
-    assert result == "success"
+    assert result.content == "success"
 
 
 def test_qa_agent_policy_selection_failed():
@@ -72,7 +72,7 @@ def test_qa_agent_policy_selection_failed():
     )
 
     result = agent.run()
-    assert "exception" in result.lower()
+    assert "exception" in result.content.lower()
 
 
 def test_qa_agent_action_execution_exception():
@@ -92,7 +92,7 @@ def test_qa_agent_action_execution_exception():
 
     result = agent.run()
 
-    assert result == "success"
+    assert result.content == "success"
 
 
 def test_qa_agent_action_execution_failed():
@@ -111,7 +111,7 @@ def test_qa_agent_action_execution_failed():
     )
 
     result = agent.run()
-    assert "exception" in result.lower()
+    assert "exception" in result.content.lower()
 
 
 class MockPolicy(BasePolicy):


### PR DESCRIPTION
# Description
Wrap the result for `agent.run` function so that we can provide more information such as status to the results. Currently, there are three status supported:
1. success if the task run is success
2. failed if the task run causes an exception
3. waiting if the task run needs input from outside

BREAKING CHANGE: because now the `agent.run` method returns an object instead of a string, the content of the task result can be accessed through `task_result.content`

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release