### PR TITLE
Fix ignoring argument type when parsing action arguments

### DIFF
--- a/src/sherpa_ai/actions/base.py
+++ b/src/sherpa_ai/actions/base.py
@@ -166,12 +166,13 @@ class BaseAction(ABC, BaseModel):
 
     def __str__(self):
         arguments = {}
-
         for arg in self.args:
             if arg.source != "agent":
                 continue
             arguments[arg.name] = (
-                arg.type if arg.description == "" else f"{arg.type}, {arg.description}"
+                arg.type
+                if arg.description == ""
+                else f"{arg.description}. Type: {arg.type}"
             )
 
         tool_desc = {"name": self.name, "args": arguments, "usage": self.usage}

--- a/src/sherpa_ai/agents/base.py
+++ b/src/sherpa_ai/agents/base.py
@@ -174,6 +174,8 @@ class BaseAgent(ABC, BaseModel):
             logger.debug(f"```Action output: {action_output}```")
 
         action_output = self.agent_finished(action_output)
+        if action_output is None:
+            action_output = ""
         task_result = TaskResult(content=action_output, status="success")
         return task_result
 


### PR DESCRIPTION
# Description
The argument parsing for actions in the state machine is currently ignoring the type of the argument. This PR fixes it.

# Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
