### PR TITLE
Refactor prompt structure in prompts.json to use a list structure wit…

### DIFF
--- a/src/sherpa_ai/actions/synthesize.py
+++ b/src/sherpa_ai/actions/synthesize.py
@@ -89,16 +89,16 @@ class SynthesizeOutput(BaseAction):
                 "history": history,
             }
             prompt = self.prompt_template.format_prompt(
-                wrapper="synthesize_prompts",
-                name="SYNTHESIZE_DESCRIPTION_CITATION" if self.add_citation else "SYNTHESIZE_DESCRIPTION",
+                prompt_parent_id="synthesize_prompts",
+                prompt_id="SYNTHESIZE_DESCRIPTION_CITATION" if self.add_citation else "SYNTHESIZE_DESCRIPTION",
                 version="1.0",
                 variables=variables
             )
 
         logger.debug("Prompt: {}", prompt)
         prompt_str = self.prompt_template.format_prompt(
-            wrapper="synthesize_prompts",
-            name="SYNTHESIZE_DESCRIPTION",
+            prompt_parent_id="synthesize_prompts",
+            prompt_id="SYNTHESIZE_DESCRIPTION",
             version="1.0",
             variables=variables
         )

--- a/src/sherpa_ai/agents/ml_engineer.py
+++ b/src/sherpa_ai/agents/ml_engineer.py
@@ -49,13 +49,13 @@ class MLEngineer(BaseAgent):
         super().__init__(*args, **kwargs)
         template = self.prompt_template
         self.description = template.format_prompt(
-            wrapper="ml_engineer_prompts",
-            name="ML_ENGINEER_DESCRIPTION",
+            prompt_parent_id="ml_engineer_prompts",
+            prompt_id="ML_ENGINEER_DESCRIPTION",
             version="1.0",
         )
         action_planner= template.format_prompt(
-            wrapper="ml_engineer_prompts",
-            name="ACTION_PLAN_DESCRIPTION",
+            prompt_parent_id="ml_engineer_prompts",
+            prompt_id="ACTION_PLAN_DESCRIPTION",
             version="1.0")
         if self.belief is None:
             self.belief = Belief()

--- a/src/sherpa_ai/agents/physicist.py
+++ b/src/sherpa_ai/agents/physicist.py
@@ -49,13 +49,13 @@ class Physicist(BaseAgent):
         super().__init__(*args, **kwargs)
         template = self.prompt_template
         action_planner = template.format_prompt(
-            wrapper="physicist_prompts",
-            name="ACTION_PLAN_DESCRIPTION",
+            prompt_parent_id="physicist_prompts",
+            prompt_id="ACTION_PLAN_DESCRIPTION",
             version="1.0",
         )
         self.description = template.format_prompt(
-            wrapper="physicist_prompts",
-            name="PHYSICIST_DESCRIPTION",
+            prompt_parent_id="physicist_prompts",
+            prompt_id="PHYSICIST_DESCRIPTION",
             version="1.0",
     )
 

--- a/src/sherpa_ai/agents/qa_agent.py
+++ b/src/sherpa_ai/agents/qa_agent.py
@@ -67,16 +67,16 @@ class QAAgent(BaseAgent):
         super().__init__(*args, **kwargs)
         template = self.prompt_template
         self.description = template.format_prompt(
-            wrapper="qa_agent_prompts",
-            name="TASK_AGENT_DESCRIPTION",
+            prompt_parent_id="qa_agent_prompts",
+            prompt_id="TASK_AGENT_DESCRIPTION",
             version="1.0",
         )
 
         self.description = self.description + "\n\n" + f"Your name is {self.name}."
 
         action_planner = template.format_prompt(
-            wrapper="qa_agent_prompts",
-            name="ACTION_PLAN_DESCRIPTION",
+            prompt_parent_id="qa_agent_prompts",
+            prompt_id="ACTION_PLAN_DESCRIPTION",
             version="1.0",
         )
 

--- a/src/sherpa_ai/policies/agent_feedback_policy.py
+++ b/src/sherpa_ai/policies/agent_feedback_policy.py
@@ -73,8 +73,8 @@ class AgentFeedbackPolicy(ReactPolicy):
 
         variables = {"task": task, "context": context, "options": options}
         agent_feedback_prompt = self.prompt_template.format_prompt(
-            wrapper="agent_feedback_description_prompt",
-            name="AGENT_FEEDBACK_DESCRIPTION_PROMPT",
+            prompt_parent_id="agent_feedback_description_prompt",
+            prompt_id="AGENT_FEEDBACK_DESCRIPTION_PROMPT",
             version="1.0",
             variables=variables,
         )

--- a/src/sherpa_ai/policies/chat_sm_policy.py
+++ b/src/sherpa_ai/policies/chat_sm_policy.py
@@ -39,8 +39,8 @@ class ChatStateMachinePolicy(BasePolicy):
 
     # Initialize base templates with placeholder variables
     SYSTEM_PROMPT: ClassVar[str] = _prompt_template.format_prompt(
-        wrapper="system_prompt",
-        name="SYSTEM_PROMPT",
+        prompt_parent_id="system_prompt",
+        prompt_id="SYSTEM_PROMPT",
         version="1.0",
         variables={
             "context": "{context}",
@@ -50,8 +50,8 @@ class ChatStateMachinePolicy(BasePolicy):
     )
 
     ACTION_SELECTION_PROMPT: ClassVar[str] = _prompt_template.format_prompt(
-        wrapper="action_selection_prompt",
-        name="ACTION_SELECTION_PROMPT",
+        prompt_parent_id="action_selection_prompt",
+        prompt_id="ACTION_SELECTION_PROMPT",
         version="1.0",
         variables={
             "state": "{state}",
@@ -95,8 +95,8 @@ class ChatStateMachinePolicy(BasePolicy):
         if state_description:
             variables = {"state": current_state, "state_description": state_description}
             formatted_state_description = self._prompt_template.format_prompt(
-                wrapper="state_description_prompt",
-                name="STATE_DESCRIPTION_PROMPT",
+                prompt_parent_id="state_description_prompt",
+                prompt_id="STATE_DESCRIPTION_PROMPT",
                 version="1.0",
                 variables=variables,
             )

--- a/src/sherpa_ai/policies/react_policy.py
+++ b/src/sherpa_ai/policies/react_policy.py
@@ -133,8 +133,8 @@ class ReactPolicy(BasePolicy):
             "response_format": response_format,
         }
         prompt = self.prompt_template.format_prompt(
-            wrapper="react_policy_prompt",
-            name="SELECTION_DESCRIPTION",
+            prompt_parent_id="react_policy_prompt",
+            prompt_id="SELECTION_DESCRIPTION",
             version="1.0",
             variables=variables,
         )

--- a/src/sherpa_ai/policies/react_sm_policy.py
+++ b/src/sherpa_ai/policies/react_sm_policy.py
@@ -97,8 +97,8 @@ class ReactStateMachinePolicy(BasePolicy):
 
         if len(state_description) > 0:
             state_description = self.prompt_template.format_prompt(
-                wrapper="react_sm_policy_prompt",
-                name="STATE_DESCRIPTION_PROMPT",
+                prompt_parent_id="react_sm_policy_prompt",
+                prompt_id="STATE_DESCRIPTION_PROMPT",
                 version="1.0",
                 variables=variables,
             )
@@ -106,8 +106,8 @@ class ReactStateMachinePolicy(BasePolicy):
         response_format = json.dumps(self.response_format, indent=4)
 
         prompt = self.prompt_template.format_prompt(
-            wrapper="react_sm_policy_prompt",
-            name="SELECTION_DESCRIPTION",
+            prompt_parent_id="react_sm_policy_prompt",
+            prompt_id="SELECTION_DESCRIPTION",
             version="1.0",
             variables={
                 "role_description": self.role_description,

--- a/src/sherpa_ai/prompts/Base.py
+++ b/src/sherpa_ai/prompts/Base.py
@@ -9,40 +9,40 @@ from pydantic import BaseModel
 from typing import List, Dict, Union
 
 
-class Prompt(BaseModel):
-    """Base class for all prompt types.
+class PromptVersion(BaseModel):
+    """Base class for all prompt versions.
 
     This class defines the common structure for all prompts in the system,
     including metadata and content.
 
     Attributes:
-        name (str): Unique identifier for the prompt.
-        description (str): Human-readable description of the prompt's purpose.
         version (str): Version identifier for the prompt.
+        change_log (str): Description of changes in this version.
+        type (str): The type of prompt (e.g., "text", "chat", "json").
         content (Union[str, List[Dict[str, str]], Dict]): The actual prompt content.
         variables (Dict): Variables that can be substituted in the prompt.
         response_format (Dict): Expected format of responses to this prompt.
 
-    Example:
-        >>> prompt = Prompt(
-        ...     name="search_prompt",
-        ...     description="Prompt for search queries",
+        Example:
+        >>> prompt = PromptVersion(
         ...     version="1.0",
+        ...     change_log="Prompt for search queries",
+        ...     type="text",
         ...     content="Search for {query}",
         ...     variables={"query": ""},
         ...     response_format={"type": "string"}
         ... )
     """
-    name: str
-    description: str
     version: str
-    content: Union[str, List[Dict[str, str]], Dict] 
+    change_log: str
+    type: str
+    content: Union[str, List[Dict[str, str]], Dict]
     variables: Dict
     response_format: Dict
 
 
-class ChatPrompt(Prompt):
-    """Prompt class for chat-based interactions.
+class ChatPromptVersion(PromptVersion):
+    """Prompt version class for chat-based interactions.
 
     This class represents prompts that consist of a sequence of chat messages,
     typically with alternating roles (e.g., system, user, assistant).
@@ -52,7 +52,7 @@ class ChatPrompt(Prompt):
             and content.
 
     Example:
-        >>> chat = ChatPrompt(
+        >>> chat = ChatPromptVersion(
         ...     name="greeting",
         ...     description="Chat greeting",
         ...     version="1.0",
@@ -66,17 +66,18 @@ class ChatPrompt(Prompt):
     """
     content: List[Dict[str, str]]
 
-class TextPrompt(Prompt):
-    """Prompt class for simple text-based prompts.
 
-    This class represents prompts that consist of a single text string,
-    which may include variable placeholders.
+class TextPromptVersion(PromptVersion):
+    """Prompt version class for simple text-based prompts.
+
+    This class represents a specific version of a prompt that consists of a
+    single text string.
 
     Attributes:
         content (str): The text content of the prompt.
 
     Example:
-        >>> text = TextPrompt(
+        >>> text = TextPromptVersion(
         ...     name="query",
         ...     description="Search query prompt",
         ...     version="1.0",
@@ -87,8 +88,9 @@ class TextPrompt(Prompt):
     """
     content: str
 
-class JsonPrompt(Prompt):
-    """Prompt class for JSON-structured prompts.
+
+class JsonPromptVersion(PromptVersion):
+    """Prompt version class for JSON-structured prompts.
 
     This class represents prompts that have a structured JSON format,
     useful for complex templates or structured data.
@@ -97,7 +99,7 @@ class JsonPrompt(Prompt):
         content (Dict): The JSON content of the prompt.
 
     Example:
-        >>> json = JsonPrompt(
+        >>> json = JsonPromptVersion(
         ...     name="api_request",
         ...     description="API request template",
         ...     version="1.0",
@@ -109,6 +111,22 @@ class JsonPrompt(Prompt):
     content: Dict
 
 
+class Prompt(BaseModel):
+    """Base class for all prompt types.
+
+    This class defines the common structure for all prompts in the system,
+    including metadata and a list of its versions.
+
+    Attributes:
+        prompt_id (str): Unique identifier for the prompt.
+        description (str): Human-readable description of the prompt's purpose.
+        versions (List[PromptVersion]): A list of different versions of this prompt.
+    """
+    prompt_id: str
+    description: str
+    versions: List[PromptVersion]
+
+
 class PromptGroup(BaseModel):
     """Group of related prompts.
 
@@ -116,17 +134,17 @@ class PromptGroup(BaseModel):
     easier to manage and retrieve sets of related prompts.
 
     Attributes:
-        name (str): Name of the prompt group.
+        prompt_parent_id (str): Name of the prompt group.
         description (str): Description of the group's purpose.
         prompts (List[Prompt]): List of prompts in this group.
 
     Example:
         >>> group = PromptGroup(
-        ...     name="search_prompts",
+        ...     prompt_parent_id="search_prompts",
         ...     description="Prompts for search operations",
         ...     prompts=[text_prompt, chat_prompt]
         ... )
     """
-    name: str
+    prompt_parent_id: str
     description: str
     prompts: List[Prompt]

--- a/src/sherpa_ai/prompts/prompt_loader.py
+++ b/src/sherpa_ai/prompts/prompt_loader.py
@@ -11,12 +11,23 @@ import json
 from pydantic import ValidationError
 from pathlib import Path
 
-from sherpa_ai.prompts.Base import ChatPrompt, Prompt, PromptGroup, TextPrompt, JsonPrompt
+from sherpa_ai.prompts.Base import (
+    ChatPromptVersion,
+    Prompt,
+    PromptGroup,
+    TextPromptVersion,
+    JsonPromptVersion,
+    PromptVersion
+)
 
 PROMPTS_ATTR = "prompts"
 CONTENT_ATTR = "content"
 RESPONSE_FORMAT_ATTR = "response_format"
 TYPE_ATTR = "type"
+PROMPT_PARENT_ID_ATTR = "prompt_parent_id"
+PROMPT_ID_ATTR = "prompt_id"
+VERSIONS_ATTR = "versions"
+VERSION_ATTR = "version"
 
 
 class JsonToObject:
@@ -37,35 +48,55 @@ class JsonToObject:
         """Initialize from JSON data.
 
         Args:
-            json_data (Union[str, dict]): JSON string or dictionary to convert.
+            json_data (Union[str, dict, list]): JSON string, dictionary, or list to convert.
         """
         if isinstance(json_data, str):
             data = json.loads(json_data)
         else:
             data = json_data
-            
-        for key, value in data.items():
-            if isinstance(value, dict):
-                value = JsonToObject(value)
-            elif isinstance(value, list):
-                value = [JsonToObject(item) if isinstance(item, dict) else item for item in value]
-            setattr(self, key, value)
-        
+
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    value = JsonToObject(value)
+                elif isinstance(value, list):
+                    value = [JsonToObject(item) if isinstance(item, dict) else item for item in value]
+                setattr(self, key, value)
+        elif isinstance(data, list):
+            self._list_data = [JsonToObject(item) if isinstance(item, dict) else item for item in data]
+        else:
+            self._value = data
+
+
     def __repr__(self):
+        if hasattr(self, '_list_data'):
+            return f"{self._list_data}"
+        elif hasattr(self, '_value'):
+            return f"{self._value}"
         return f"{self.__dict__}"
 
+    def __iter__(self):
+        if hasattr(self, '_list_data'):
+            return iter(self._list_data)
+        raise TypeError("JsonToObject is not iterable unless initialized with a list root.")
 
-def load_json(file_path: str) -> Dict:
+    def __getitem__(self, key):
+        if hasattr(self, '_list_data'):
+            return self._list_data[key]
+        raise TypeError("JsonToObject does not support indexing unless initialized with a list root.")
+
+
+def load_json(file_path: str) -> Union[Dict, List]:
     """Load JSON data from a file path or package resource.
-    
+
     This function attempts to load JSON data first from the package resources,
     then from the filesystem if not found in resources.
-    
+
     Args:
         file_path (str): Path to JSON file (relative to sherpa_ai or absolute).
 
     Returns:
-        Dict: Loaded JSON data as a dictionary.
+        Union[Dict, List]: Loaded JSON data as a dictionary or list.
 
     Raises:
         FileNotFoundError: If file not found in resources or filesystem.
@@ -96,14 +127,14 @@ def load_json(file_path: str) -> Dict:
         raise FileNotFoundError(f"File not found: {file_path}") from e
 
 
-def get_prompts(data: Dict) -> Dict[str, List[Dict]]:
+def get_prompts(data: Union[Dict, List]) -> Dict[str, List[Dict]]:
     """Extract prompts from loaded JSON data.
 
     This function processes the JSON data structure to extract all prompts,
     organizing them by their wrapper names.
 
     Args:
-        data (Dict): JSON data containing prompt definitions.
+        data (Union[Dict, List]): JSON data containing prompt definitions.
 
     Returns:
         Dict[str, List[Dict]]: Dictionary mapping wrapper names to prompt lists.
@@ -115,11 +146,18 @@ def get_prompts(data: Dict) -> Dict[str, List[Dict]]:
         2
     """
     all_prompts = {}
-    for wrapper, items in data.items():
-        all_prompts[wrapper] = []
-        for item in items:
-            prompts = item.get(PROMPTS_ATTR, [])
-            all_prompts[wrapper].extend(prompts)
+    if isinstance(data, list):
+        for item_data in data:
+            wrapper_name = item_data.get(PROMPT_PARENT_ID_ATTR)
+            if wrapper_name:
+                prompts = item_data.get(PROMPTS_ATTR, [])
+                all_prompts[wrapper_name] = prompts
+    elif isinstance(data, dict):
+        for wrapper, items in data.items():
+            all_prompts[wrapper] = []
+            for item in items:
+                prompts = item.get(PROMPTS_ATTR, [])
+                all_prompts[wrapper].extend(prompts)
     return all_prompts
 
 
@@ -146,12 +184,12 @@ class PromptLoader:
     structure, and providing access to individual prompts.
 
     Attributes:
-        data (JsonToObject): Raw JSON data converted to objects.
+        data (Union[Dict, List]): Raw JSON data.
         prompts (List[PromptGroup]): Validated prompt groups.
 
     Example:
         >>> loader = PromptLoader("prompts.json")
-        >>> prompt = loader.get_prompt("wrapper", "name", "1.0")
+        >>> prompt = loader.get_prompt("prompt_parent_id", "prompt_id", "1.0")
         >>> print(prompt.content)
         'Hello {name}!'
     """
@@ -163,17 +201,15 @@ class PromptLoader:
             json_file_path (str): Path to JSON file containing prompts.
         """
         raw_data = load_json(json_file_path)
-        self.data = JsonToObject(raw_data)
+        self.data = raw_data
         self.prompts = self._process_prompts()
 
-    def _validate_prompt_structure(self, prompt: Dict) -> bool:
-        """Validate prompt structure and types.
-
+    def _validate_prompt_version_structure(self, version_data: Dict) -> bool:
+        """Validate the structure and types of a single prompt version.
         This method checks that a prompt dictionary has all required fields
         with correct types.
-
         Args:
-            prompt (Dict): Prompt dictionary to validate.
+            version_data (Dict): Dictionary representing a prompt version.
 
         Returns:
             bool: True if validation passes.
@@ -182,23 +218,25 @@ class PromptLoader:
             InvalidPromptContentError: If validation fails.
         """
         required_attrs = {
-            "name": str,
-            "version": str,
-            "type": str,
-            "content": (str, list, dict),
+            VERSION_ATTR: str,
+            "change_log": str,
+            TYPE_ATTR: str,
+            CONTENT_ATTR: (str, list, dict),
+            "variables": dict,
+            RESPONSE_FORMAT_ATTR: dict,
         }
 
         for attr, expected_type in required_attrs.items():
-            if attr not in prompt:
-                raise InvalidPromptContentError(f"Prompt must have '{attr}' attribute.")
-            if not isinstance(prompt[attr], expected_type):
+            if attr not in version_data:
+                raise InvalidPromptContentError(f"Prompt version must have '{attr}' attribute.")
+            if not isinstance(version_data[attr], expected_type):
                 raise InvalidPromptContentError(
-                    f"'{attr}' must be of type {expected_type} for prompt '{prompt.get('name', 'Unknown')}'. "
-                    f"Found '{type(prompt[attr]).__name__}'."
+                    f"'{attr}' must be of type {expected_type} for version '{version_data.get(VERSION_ATTR, 'Unknown')}'. "
+                    f"Found '{type(version_data[attr]).__name__}'."
                 )
 
-        content_type = prompt.get(TYPE_ATTR)
-        content = prompt.get(CONTENT_ATTR)
+        content_type = version_data.get(TYPE_ATTR)
+        content = version_data.get(CONTENT_ATTR)
 
         if content_type == "text" and not isinstance(content, str):
             raise InvalidPromptContentError("'content' must be a string when 'type' is 'text'.")
@@ -220,118 +258,122 @@ class PromptLoader:
         Raises:
             InvalidPromptContentError: If validation fails.
         """
-        validated_prompts = []
-        for wrapper, items in self.data.__dict__.items():
-            for item in items:
-                try:
-                    item_dict = self._convert_to_dict(item)
-                    processed_prompts = []
-
-                    for prompt_data in item_dict[PROMPTS_ATTR]:
-                        self._validate_prompt_structure(prompt_data)
-                        content_type = prompt_data.get(TYPE_ATTR)
-                        if content_type == "chat":
-                            prompt = ChatPrompt(**prompt_data)
-                        elif content_type == "text":
-                            prompt = TextPrompt(**prompt_data)
-                        elif content_type == "json":
-                            prompt = JsonPrompt(**prompt_data)
-                        else:
-                            raise InvalidPromptContentError(f"Unknown 'type': {content_type}")
-                        processed_prompts.append(prompt)
-
-                    item_dict[PROMPTS_ATTR] = processed_prompts
-                    prompt_group = PromptGroup(**item_dict)
-                    validated_prompts.append(prompt_group)
-
-                except ValidationError as e:
-                    error_details = [
-                        f"Field '{'.'.join(str(loc) for loc in err['loc'])}': {err['msg']}"
-                        for err in e.errors()
-                    ]
+        validated_prompt_groups = []
+        for prompt_group_data in self.data:
+            try:
+                if not isinstance(prompt_group_data, dict):
                     raise InvalidPromptContentError(
-                        f"Validation failed for prompts in '{wrapper}': {', '.join(error_details)}"
-                    ) from e
+                        f"Expected a dictionary for prompt group, but got {type(prompt_group_data).__name__}."
+                    )
 
-        return validated_prompts
+                processed_prompts = []
+                for prompt_data in prompt_group_data.get(PROMPTS_ATTR, []):
+                    # Validate prompt_id and description for the Prompt itself
+                    if PROMPT_ID_ATTR not in prompt_data or not isinstance(prompt_data[PROMPT_ID_ATTR], str):
+                        raise InvalidPromptContentError(f"Prompt must have a string '{PROMPT_ID_ATTR}' attribute.")
+                    if "description" not in prompt_data or not isinstance(prompt_data["description"], str):
+                        raise InvalidPromptContentError(f"Prompt '{prompt_data.get(PROMPT_ID_ATTR, 'Unknown')}' must have a string 'description' attribute.")
 
-    def _convert_to_dict(self, obj: Any) -> Any:
-        """Recursively convert JsonToObject instances to dictionaries.
+
+                    processed_versions = []
+                    if VERSIONS_ATTR not in prompt_data or not isinstance(prompt_data[VERSIONS_ATTR], list):
+                        raise InvalidPromptContentError(
+                            f"Prompt '{prompt_data.get(PROMPT_ID_ATTR, 'Unknown')}' must have a list '{VERSIONS_ATTR}' attribute."
+                        )
+
+                    for version_data in prompt_data[VERSIONS_ATTR]:
+                        self._validate_prompt_version_structure(version_data)
+                        content_type = version_data.get(TYPE_ATTR)
+
+                        if content_type == "chat":
+                            prompt_version = ChatPromptVersion(**version_data)
+                        elif content_type == "text":
+                            prompt_version = TextPromptVersion(**version_data)
+                        elif content_type == "json":
+                            prompt_version = JsonPromptVersion(**version_data)
+                        else:
+                            raise InvalidPromptContentError(f"Unknown 'type': {content_type} in prompt version.")
+                        processed_versions.append(prompt_version)
+
+                    prompt_obj = Prompt(
+                        prompt_id=prompt_data[PROMPT_ID_ATTR],
+                        description=prompt_data["description"],
+                        versions=processed_versions
+                    )
+                    processed_prompts.append(prompt_obj)
+
+                prompt_group_obj = PromptGroup(
+                    prompt_parent_id=prompt_group_data[PROMPT_PARENT_ID_ATTR],
+                    description=prompt_group_data["description"],
+                    prompts=processed_prompts
+                )
+                validated_prompt_groups.append(prompt_group_obj)
+
+            except ValidationError as e:
+                error_details = [
+                    f"Field '{'.'.join(str(loc) for loc in err['loc'])}': {err['msg']}"
+                    for err in e.errors()
+                ]
+                raise InvalidPromptContentError(
+                    f"Validation failed for prompt group: {', '.join(error_details)}"
+                ) from e
+            except KeyError as e:
+                raise InvalidPromptContentError(f"Missing expected key in prompt group data: {e}") from e
+
+        return validated_prompt_groups
+
+    def get_prompt_version(self, prompt_parent_id: str, prompt_id: str, version: str) -> Optional[PromptVersion]:
+        """Get a specific prompt version by its identifiers.
 
         Args:
-            obj (Any): Object to convert.
+            prompt_parent_id (str): Prompt group ID.
+            prompt_id (str): Unique identifier for the prompt.
+            version (str): Specific version of the prompt.
 
         Returns:
-            Any: Converted object (dict if input was JsonToObject).
-        """
-        if isinstance(obj, JsonToObject):
-            return {key: self._convert_to_dict(value) for key, value in obj.__dict__.items()}
-        elif isinstance(obj, list):
-            return [self._convert_to_dict(item) for item in obj]
-        return obj
-
-    def get_prompt(self, wrapper: str, name: str, version: str) -> Optional[Prompt]:
-        """Get a specific prompt by its identifiers.
-
-        Args:
-            wrapper (str): Wrapper name containing the prompt.
-            name (str): Name of the prompt.
-            version (str): Version of the prompt.
-
-        Returns:
-            Optional[Prompt]: The requested prompt if found, None otherwise.
-
-        Example:
-            >>> prompt = loader.get_prompt("chat", "greeting", "1.0")
-            >>> if prompt:
-            ...     print(prompt.content)
-            'Hello {name}!'
+            Optional[PromptVersion]: The requested prompt version if found, None otherwise.
         """
         for prompt_group in self.prompts:
-            if prompt_group.name == wrapper:
+            if prompt_group.prompt_parent_id == prompt_parent_id:
                 for prompt in prompt_group.prompts:
-                    if prompt.name == name and prompt.version == version:
-                        return prompt
+                    if prompt.prompt_id == prompt_id:
+                        for prompt_version in prompt.versions:
+                            if prompt_version.version == version:
+                                return prompt_version
         return None
 
-    def get_prompt_content(self, wrapper: str, name: str, version: str) -> Optional[Any]:
-        """Get the content of a specific prompt.
+    def get_prompt_content(self, prompt_parent_id: str, prompt_id: str, version: str) -> Optional[Any]:
+        """Get the content of a specific prompt version.
 
         Args:
-            wrapper (str): Wrapper name containing the prompt.
-            name (str): Name of the prompt.
-            version (str): Version of the prompt.
+            prompt_parent_id (str): Prompt group ID.
+            prompt_id (str): Unique identifier for the prompt.
+            version (str): Specific version of the prompt.
 
         Returns:
-            Optional[Any]: The prompt content if found, None otherwise.
+            Optional[Any]: The prompt version's content if found, None otherwise.
+        """
+        prompt_version = self.get_prompt_version(prompt_parent_id, prompt_id, version)
+        if prompt_version:
+            return prompt_version.content
+        return None
 
+    def get_prompt_output_schema(self, prompt_parent_id: str, prompt_id: str, version: str) -> Optional[Dict]:
+        """Get the output schema of a specific prompt version.
+
+        Args:
+            prompt_parent_id (str): Prompt group ID.
+            prompt_id (str): Unique identifier for the prompt.
+            version (str): Specific version of the prompt.
+
+        Returns:
+            Optional[Dict]: The prompt version's response format (output schema) if found, None otherwise.
         Example:
             >>> content = loader.get_prompt_content("chat", "greeting", "1.0")
             >>> print(content)
             'Hello {name}!'
         """
-        prompt = self.get_prompt(wrapper, name, version)
-        if prompt:
-            return prompt.content
-        return None
-
-    def get_prompt_output_schema(self, wrapper: str, name: str, version: str) -> Optional[Any]:
-        """Get the output schema of a specific prompt.
-
-        Args:
-            wrapper (str): Wrapper name containing the prompt.
-            name (str): Name of the prompt.
-            version (str): Version of the prompt.
-
-        Returns:
-            Optional[Any]: The prompt's output schema if found, None otherwise.
-
-        Example:
-            >>> schema = loader.get_prompt_output_schema("chat", "greeting", "1.0")
-            >>> print(schema["type"])
-            'string'
-        """
-        prompt = self.get_prompt(wrapper, name, version)
-        if prompt and hasattr(prompt, RESPONSE_FORMAT_ATTR):
-            return prompt.response_format
+        prompt_version = self.get_prompt_version(prompt_parent_id, prompt_id, version)
+        if prompt_version and hasattr(prompt_version, RESPONSE_FORMAT_ATTR):
+            return prompt_version.response_format
         return None

--- a/src/sherpa_ai/prompts/prompts.json
+++ b/src/sherpa_ai/prompts/prompts.json
@@ -1,395 +1,479 @@
-{
-  "synthesize_prompts": [
-    {
-      "name": "synthesize_prompts",
-      "description": "Generate a response based on context and task with history.",
-      "prompts": [
-        {
-          "name": "SYNTHESIZE_DESCRIPTION",
-          "version": "1.0",
-          "description": "Generate a response based on context and task with history.",
-          "type": "chat",
-          "content": [
-            {
-              "role": "system",
-              "content": "{role_description}"
-            },
-            {
-              "role": "user",
-              "content": "Context: {context}\n\nAction - Result History:\n{history}\n\nGiven the context and the action-result history, please complete the task mentioned. Task: {task} Result:"
-            }
-          ],
-          "variables": {
-            "role_description": "",
-            "context": "",
-            "history": "",
-            "task": ""
-          },
-          "response_format": {}
-        },
-        {
-          "name": "SYNTHESIZE_DESCRIPTION_CITATION",
-          "version": "1.0",
-          "description": "Generate a response with citations based on context and task with history.",
-          "type": "chat",
-          "content": [
-            {
-              "role": "system",
-              "content": "{role_description}"
-            },
-            {
-              "role": "user",
-              "content": "Context: {context}\n\nAction - Result History:\n{history}\n\nGiven the context and the action-result history, please complete the task mentioned and cite context as much as possible. Task: {task} Result:"
-            }
-          ],
-          "variables": {
-            "role_description": "",
-            "context": "",
-            "history": "",
-            "task": ""
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "qa_agent_prompts": [
-    {
-      "name": "qa_agent_prompts",
-      "description": "The QA agent handles a single question-answering task.",
-      "prompts": [
-        {
-          "name": "ACTION_PLAN_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the action plan to solve the problem",
-          "type": "text",
-          "content": "{action_plan_description}",
-          "variables": {
-            "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate Machine-Learning-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task."
-          },
-          "response_format": {}
-        },
-        {
-          "name": "TASK_AGENT_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the role of a task agent",
-          "type": "text",
-          "content": "{task_agent_description}",
-          "variables": {
-            "task_agent_description": "You are a **question answering assistant** who solves user questions and offers a detailed solution."
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "ml_engineer_prompts": [
-    {
-      "name": "ml_engineer_prompts",
-      "description": "The machine learning agent answers questions or research about ML-related topics",
-      "prompts": [
-        {
-          "name": "ACTION_PLAN_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the action plan to solve the problem",
-          "type": "text",
-          "content": "{action_plan_description}",
-          "variables": {
-            "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate Machine-Learning-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task"
-          },
-          "response_format": {}
-        },
-        {
-          "name": "ML_ENGINEER_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the role of a machine learning engineer",
-          "type": "text",
-          "content": "{ml_engineer_description}",
-          "variables": {
-            "ml_engineer_description": "You are a skilled machine learning engineer with a deep-rooted expertise in understanding and analyzing various Machine Learnng algorithm and use it to solve practical problems. \n Your primary role is to assist individuals, organizations, and researchers in using machine learning models to solve Machine-Learning-Related chalenges, \n using your knowledge to guide decisions and ensure the accuracy and reliability of outcomes.\n If you encounter a question or challenge outside your current knowledge base, you acknowledge your limitations and seek assistance or additional resources to fill the gaps."
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "physicist_prompts": [
-    {
-      "name": "physicist_prompts",
-      "description": " The physicist agent answers questions or research about physics-related topics",
-      "prompts": [
-        {
-          "name": "ACTION_PLAN_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the action plan to solve the problem",
-          "type": "text",
-          "content": "{action_plan_description}",
-          "variables": {
-            "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate physics-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task."
-          },
-          "response_format": {}
-        },
-        {
-          "name": "PHYSICIST_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the role of a physicist",
-          "type": "text",
-          "content": "{physicist_description}",
-          "variables": {
-            "physicist_description": "You are a physicist with a deep-rooted expertise in understanding and analyzing the fundamental principles of the universe, spanning from the tiniest subatomic particles to vast cosmic phenomena. Your primary role is to assist individuals, organizations, and researchers in navigating and resolving complex physics-related challenges, using your knowledge to guide decisions and ensure the accuracy and reliability of outcomes."
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "planner_prompts": [
-    {
-      "name": "planner_prompts",
-      "description": "Provide a sequential steps by breaking down complex steps",
-      "prompts": [
-        {
-          "name": "PLANNER_DESCRIPTION",
-          "version": "1.0",
-          "description": "Describe the role of a planner",
-          "type": "text",
-          "content": "{planner_description}",
-          "variables": {
-            "planner_description": "You are a **task decomposition assistant** who simplifies complex tasks into sequential steps, assigning roles or agents to each. \n By analyzing user-defined tasks and agent capabilities, you provide structured plans, enhancing project clarity and efficiency.\n Your adaptability ensures customized solutions for diverse needs."
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "critic_prompts": [
-    {
-      "name": "critic_prompts",
-      "description": "The critic agent receives a plan from the planner and evaluate the plan based on some pre-defined metrics. At the same time, it gives the feedback to the planner.",
-      "prompts": [
-        {
-          "name": "DESCRIPTION_PROMPT",
-          "version": "1.0",
-          "description": "Describe the role of a critic",
-          "type": "text",
-          "content": "{description_prompt}",
-          "variables": {
-            "description_prompt": "You are a Critic agent that receive a plan from the planner to execuate a task from user.\n Your goal is to output the {} most necessary feedback given the corrent plan to solve the task."
-          },
-          "response_format": {}
-        },
-        {
-          "name": "IMPORTANCE_PROMPT",
-          "version": "1.0",
-          "description": "describe the role of importance prompt",
-          "type": "text",
-          "content": "Task: {task} \n Plan: {plan} {importance_prompt}",
-          "variables": {
-            "importance_prompt": "The plan you should be necessary and important to complete the task.\n Evaluate if the content of plan and selected actions/ tools are important and necessary. \n Output format:\n Score: <Integer score from 1 - 10>\n Evaluation: <evaluation in text>\n Do not include other text in your resonse.\n Output:",
-            "task": "",
-            "plan": ""
-          },
-          "response_format": {}
-        },
-        {
-          "name": "DETAIL_PROMPT",
-          "version": "1.0",
-          "description": "describe the role of detail prompt",
-          "type": "text",
-          "content": "Task: {task} \n Plan: {plan} {detail_prompt}",
-          "variables": {
-            "detail_prompt": "The plan you should be detailed enough to complete the task.\n Evaluate if the content of plan and selected actions/ tools contains all the details the task needed.\n Output format:\n Score: <Integer score from 1 - 10>\n Evaluation: <evaluation in text>\n Do not include other text in your resonse.\n Output:",
-            "task": "",
-            "plan": ""
-          },
-          "response_format": {}
-        },
-        {
-          "name": "INSIGHT_PROMPT",
-          "version": "1.0",
-          "description": "describe the role of insight prompt",
-          "type": "text",
-          "content": "Observation: {observation} \n {insight_prompt}",
-          "variables": {
-            "insight_prompt": "What are the top 5 high-level insights you can infer from the all the memory you have?\n Only output insights with high confidence.\n Insight:",
-            "observation": ""
-          },
-          "response_format": {}
-        },
-        {
-          "name": "EVALUATION_PROMPT",
-          "version": "1.0",
-          "description": "describe the role of evaluation prompt",
-          "type": "text",
-          "content": "Task: {task} \n Evaluation in the importance matrices: {i_evaluation}\n Evaluation in the detail matrices: {d_evaluation} ",
-          "variables": {
-            "task": "",
-            "i_evaluation": "",
-            "d_evaluation": ""
-          },
-          "response_format": {}
-        },
-        {
-          "name": "FEEDBACK_PROMPT",
-          "version": "1.0",
-          "description": "describe the role of feedback prompt",
-          "type": "text",
-          "content": "What are the {num_feedback} most important feedback for the plan received from the planner, using the\n insight you have from current observation, evaluation using the importance matrices and detail matrices.\n Feedback:",
-          "variables": {
-            "num_feedback": ""
-          },
-          "response_format": {}
-        }
-      ]
-    }
-  ],
-  "system_prompt":[
+[
+  {
+    "prompt_parent_id": "synthesize_prompts",
+    "description": "Generate a response based on context and task with history.",
+    "prompts": [
       {
-          "name": "system_prompt",
-          "description": "Description of system prompt",
-          "prompts":[
+        "prompt_id": "SYNTHESIZE_DESCRIPTION",
+        "description": "Generate a response based on context and task with history.",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for synthesis with history.",
+            "type": "chat",
+            "content": [
               {
-                  "name": "SYSTEM_PROMPT",
-                  "version": "1.0",
-                  "description": "Description of system prompt",
-                  "type": "text",
-                  "content": "You are an assistant that must parse the user's instructions and select the most appropriate action from the provided possibilities. Only respond with valid JSON as described, without any extra text. Comply strictly with the specified format.\n\n**Task Description**: {task_description}\n\nYou should only respond in JSON format as described below without any extra text.\nResponse Format:\n{response_format}\nEnsure the response can be parsed by Python json.loads",
-                  "variables":{
-                      "context": "",
-                      "task_description": "",
-                      "response_format": ""
-                  },
-                  "response_format":{}
-
-              }
-          ]
-      }
-  ],
-  "action_selection_prompt":[
-      {
-          "name": "action_selection_prompt",
-          "description": "Description of action selection prompt",
-          "prompts":[
-              {
-                  "name": "ACTION_SELECTION_PROMPT",
-                  "version": "1.0",
-                  "description": "Description of action selection prompt",
-                  "type": "text",
-                  "content": "You have a state machine to help you with the action execution. You are currently in the {state} state.\n{state_description}\n\n## Possible Actions:\n{possible_actions}\n\nYou should only select the actions specified in **Possible Actions**\nFirst, reason about what to do next based on the information, then select the best action.",
-                  "variables":{
-                      "state": "",
-                      "state_description": "",
-                      "possible_actions": ""
-                  },
-                  "response_format":{}
-
-              }
-          ]
-      }
-  ],
-  "state_description_prompt":[
-      {
-          "name": "state_description_prompt",
-          "description": "Description of state description prompt",
-          "prompts":[
-              {
-                  "name": "STATE_DESCRIPTION_PROMPT",
-                  "version": "1.0",
-                  "description": "Description of state description prompt",
-                  "type": "text",
-                  "content": "The {state} state has the following instruction:\n {state_description}",
-                  "variables":{
-                      "state": "",
-                      "state_description": ""
-                  },
-                  "response_format":{}
-              }
-          ]
-      }
-  ],
-  "agent_feedback_description_prompt":[
-      {
-          "name": "agent_feedback_description_prompt",
-          "description": "Description of agent feedback description prompt",
-          "prompts":[
-              {
-                  "name": "AGENT_FEEDBACK_DESCRIPTION_PROMPT",
-                  "version": "1.0",
-                  "description": "Description of agent feedback description prompt",
-                  "type": "text",
-                  "content": "You are an intelligent assistant helping the user to complete their task.\n\nYou have the following task to complete:\n{task}\n\nContext of your work is as follows:\n{context}\n\nYou have the following options to continue completing this task:\n\n{options}\n\nUse polite and engaging language, and ask the user what they want you to help them with next. No need to greet and keep it short and concise.\n\nIf you think the context is not enough to choose an action, ask the user for more information.",
-                  "variables":{
-                      "task":"",
-                      "context": "",
-                      "options":""
-                  },
-                  "response_format":{}
-              }
-          ]
-      }
-  ],
-  "react_policy_prompt":[
-      {
-          "name": "react_policy_prompt",
-          "description": "Description of react policy prompt",
-          "prompts":[
-              {
-                  "name": "SELECTION_DESCRIPTION",
-                  "version": "1.0",
-                  "description": "Description of react policy prompt",
-                  "type": "text",
-                  "content": "{role_description}\\n\\n{output_instruction}\\n\\n**Task Description**: {task_description}\\n\\n**IMPORTANT - Available Actions**:\\n{possible_actions}\\n\\nYou MUST ONLY select from the actions listed above. DO NOT try to use any actions that are not explicitly listed.\\n\\n**Task Context**:\\n{task_context}\\n\\n**History of Previous Actions**:\\n{history_of_previous_actions}\\n\\nSTRICT REQUIREMENTS:\\n1. You must ONLY select actions that are listed under 'Available Actions' above\\n2. If you need an action that is not listed, you must work with the actions that ARE available\\n3. Respond ONLY in the JSON format specified below\\n4. No additional text or explanations - ONLY the JSON response\\n\\nResponse Format:\\n{response_format}\\n\\nEnsure the response can be parsed by Python json.loads.",
-                  "variables":{
-                      "role_description":"",
-                      "output_instruction": "",
-                      "task_description":"",
-                      "possible_actions":"",
-                      "task_context":"",
-                      "history_of_previous_actions":"",
-                      "response_format":""
-                  },
-                  "response_format":{}
-              }
-          ]
-      }
-  ],
-  "react_sm_policy_prompt":[
-      {
-          "name": "react_sm_policy_prompt",
-          "description": "Description of react sm policy prompt",
-          "prompts":[
-              {
-                  "name": "SELECTION_DESCRIPTION",
-                  "version": "1.0",
-                  "description": "Description of react sm policy prompt",
-                  "type": "text",
-                  "content": "{role_description}\\n\\n## History of Previous Actions\\n{history_of_previous_actions}\\n\\nYou have a state machine to help you with the action execution. You are currently in the {state} state.\\n{state_description}\\n\\n## Possible Actions:\\n{possible_actions}\\n\\n**Task Description**: {task_description}\\n\\nYou should only select the actions specified in **Possible Actions**.\\nYou should only respond in JSON format as described below without any extra text.\\n\\nResponse Format:\\n{response_format}\\n\\nEnsure the response can be parsed by Python json.loads.\\n\\n{output_instruction}",
-                  "variables":{
-                    "role_description":"",
-                    "context":"",
-                    "history_of_previous_actions":"",
-                    "state":"",
-                    "state_description":"",
-                    "possible_actions":"",
-                    "task_description":"",
-                    "response_format":"",
-                    "output_instruction":""
-                  },
-                  "response_format":{}
+                "role": "system",
+                "content": "{role_description}"
               },
               {
-                "name": "STATE_DESCRIPTION_PROMPT",
-                "version": "1.0",
-                "description": "Description of state description prompt",
-                "type": "text",
-                "content": "The {state} state has the following instruction:\n{state_description}",
-                "variables":{
-                  "state":"",
-                  "state_description":""
-                },
-                "response_format":{}
+                "role": "user",
+                "content": "Context: {context}\n\nAction - Result History:\n{history}\n\nGiven the context and the action-result history, please complete the task mentioned. Task: {task} Result:"
               }
-          ]
+            ],
+            "variables": {
+              "role_description": "",
+              "context": "",
+              "history": "",
+              "task": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "SYNTHESIZE_DESCRIPTION_CITATION",
+        "description": "Generate a response with citations based on context and task with history.",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for synthesis with citations.",
+            "type": "chat",
+            "content": [
+              {
+                "role": "system",
+                "content": "{role_description}"
+              },
+              {
+                "role": "user",
+                "content": "Context: {context}\n\nAction - Result History:\n{history}\n\nGiven the context and the action-result history, please complete the task mentioned and cite context as much as possible. Task: {task} Result:"
+              }
+            ],
+            "variables": {
+              "role_description": "",
+              "context": "",
+              "history": "",
+              "task": ""
+            },
+            "response_format": {}
+          }
+        ]
       }
-  ]
-}
+    ]
+  },
+  {
+    "prompt_parent_id": "qa_agent_prompts",
+    "description": "The QA agent handles a single question-answering task.",
+    "prompts": [
+      {
+        "prompt_id": "ACTION_PLAN_DESCRIPTION",
+        "description": "Describe the action plan to solve the problem",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for QA agent action plan.",
+            "type": "text",
+            "content": "{action_plan_description}",
+            "variables": {
+              "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate Machine-Learning-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task."
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "TASK_AGENT_DESCRIPTION",
+        "description": "Describe the role of a task agent",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for QA agent task description.",
+            "type": "text",
+            "content": "{task_agent_description}",
+            "variables": {
+              "task_agent_description": "You are a **question answering assistant** who solves user questions and offers a detailed solution."
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "ml_engineer_prompts",
+    "description": "The machine learning agent answers questions or research about ML-related topics",
+    "prompts": [
+      {
+        "prompt_id": "ACTION_PLAN_DESCRIPTION",
+        "description": "Describe the action plan to solve the problem",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for ML engineer action plan.",
+            "type": "text",
+            "content": "{action_plan_description}",
+            "variables": {
+              "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate Machine-Learning-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task"
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "ML_ENGINEER_DESCRIPTION",
+        "description": "Describe the role of a machine learning engineer",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for ML engineer role description.",
+            "type": "text",
+            "content": "{ml_engineer_description}",
+            "variables": {
+              "ml_engineer_description": "You are a skilled machine learning engineer with a deep-rooted expertise in understanding and analyzing various Machine Learnng algorithm and use it to solve practical problems. \n Your primary role is to assist individuals, organizations, and researchers in using machine learning models to solve Machine-Learning-Related chalenges, \n using your knowledge to guide decisions and ensure the accuracy and reliability of outcomes.\n If you encounter a question or challenge outside your current knowledge base, you acknowledge your limitations and seek assistance or additional resources to fill the gaps."
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "physicist_prompts",
+    "description": "The physicist agent answers questions or research about physics-related topics",
+    "prompts": [
+      {
+        "prompt_id": "ACTION_PLAN_DESCRIPTION",
+        "description": "Describe the action plan to solve the problem",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for physicist action plan.",
+            "type": "text",
+            "content": "{action_plan_description}",
+            "variables": {
+              "action_plan_description": "Given your specialized expertise, historical context, and your mission to facilitate physics-based solutions, determine which action and its corresponding arguments would be the most scientifically sound and efficient approach to achieve the described task."
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "PHYSICIST_DESCRIPTION",
+        "description": "Describe the role of a physicist",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for physicist role description.",
+            "type": "text",
+            "content": "{physicist_description}",
+            "variables": {
+              "physicist_description": "You are a physicist with a deep-rooted expertise in understanding and analyzing the fundamental principles of the universe, spanning from the tiniest subatomic particles to vast cosmic phenomena. Your primary role is to assist individuals, organizations, and researchers in navigating and resolving complex physics-related challenges, using your knowledge to guide decisions and ensure the accuracy and reliability of outcomes."
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "planner_prompts",
+    "description": "Provide a sequential steps by breaking down complex steps",
+    "prompts": [
+      {
+        "prompt_id": "PLANNER_DESCRIPTION",
+        "description": "Describe the role of a planner",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for planner role description.",
+            "type": "text",
+            "content": "{planner_description}",
+            "variables": {
+              "planner_description": "You are a **task decomposition assistant** who simplifies complex tasks into sequential steps, assigning roles or agents to each. \n By analyzing user-defined tasks and agent capabilities, you provide structured plans, enhancing project clarity and efficiency.\n Your adaptability ensures customized solutions for diverse needs."
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "critic_prompts",
+    "description": "The critic agent receives a plan from the planner and evaluate the plan based on some pre-defined metrics. At the same time, it gives the feedback to the planner.",
+    "prompts": [
+      {
+        "prompt_id": "DESCRIPTION_PROMPT",
+        "description": "Describe the role of a critic",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for critic role description.",
+            "type": "text",
+            "content": "{description_prompt}",
+            "variables": {
+              "description_prompt": "You are a Critic agent that receive a plan from the planner to execuate a task from user.\n Your goal is to output the {} most necessary feedback given the corrent plan to solve the task."
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "IMPORTANCE_PROMPT",
+        "description": "describe the role of importance prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for importance prompt.",
+            "type": "text",
+            "content": "Task: {task} \n Plan: {plan} {importance_prompt}",
+            "variables": {
+              "importance_prompt": "The plan you should be necessary and important to complete the task.\n Evaluate if the content of plan and selected actions/ tools are important and necessary. \n Output format:\n Score: <Integer score from 1 - 10>\n Evaluation: <evaluation in text>\n Do not include other text in your resonse.\n Output:",
+              "task": "",
+              "plan": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "DETAIL_PROMPT",
+        "description": "describe the role of detail prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for detail prompt.",
+            "type": "text",
+            "content": "Task: {task} \n Plan: {plan} {detail_prompt}",
+            "variables": {
+              "detail_prompt": "The plan you should be detailed enough to complete the task.\n Evaluate if the content of plan and selected actions/ tools contains all the details the task needed.\n Output format:\n Score: <Integer score from 1 - 10>\n Evaluation: <evaluation in text>\n Do not include other text in your resonse.\n Output:",
+              "task": "",
+              "plan": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "INSIGHT_PROMPT",
+        "description": "describe the role of insight prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for insight prompt.",
+            "type": "text",
+            "content": "Observation: {observation} \n {insight_prompt}",
+            "variables": {
+              "insight_prompt": "What are the top 5 high-level insights you can infer from the all the memory you have?\n Only output insights with high confidence.\n Insight:",
+              "observation": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "EVALUATION_PROMPT",
+        "description": "describe the role of evaluation prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for evaluation prompt.",
+            "type": "text",
+            "content": "Task: {task} \n Evaluation in the importance matrices: {i_evaluation}\n Evaluation in the detail matrices: {d_evaluation} ",
+            "variables": {
+              "task": "",
+              "i_evaluation": "",
+              "d_evaluation": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "FEEDBACK_PROMPT",
+        "description": "describe the role of feedback prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for feedback prompt.",
+            "type": "text",
+            "content": "What are the {num_feedback} most important feedback for the plan received from the planner, using the\n insight you have from current observation, evaluation using the importance matrices and detail matrices.\n Feedback:",
+            "variables": {
+              "num_feedback": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "system_prompt",
+    "description": "Description of system prompt",
+    "prompts": [
+      {
+        "prompt_id": "SYSTEM_PROMPT",
+        "description": "Description of system prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for system prompt.",
+            "type": "text",
+            "content": "You are an assistant that must parse the user's instructions and select the most appropriate action from the provided possibilities. Only respond with valid JSON as described, without any extra text. Comply strictly with the specified format.\n\n**Task Description**: {task_description}\n\nYou should only respond in JSON format as described below without any extra text.\nResponse Format:\n{response_format}\nEnsure the response can be parsed by Python json.loads",
+            "variables": {
+              "context": "",
+              "task_description": "",
+              "response_format": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "action_selection_prompt",
+    "description": "Description of action selection prompt",
+    "prompts": [
+      {
+        "prompt_id": "ACTION_SELECTION_PROMPT",
+        "description": "Description of action selection prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for action selection prompt.",
+            "type": "text",
+            "content": "You have a state machine to help you with the action execution. You are currently in the {state} state.\n{state_description}\n\n## Possible Actions:\n{possible_actions}\n\nYou should only select the actions specified in **Possible Actions**\nFirst, reason about what to do next based on the information, then select the best action.",
+            "variables": {
+              "state": "",
+              "state_description": "",
+              "possible_actions": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "state_description_prompt",
+    "description": "Description of state description prompt",
+    "prompts": [
+      {
+        "prompt_id": "STATE_DESCRIPTION_PROMPT",
+        "description": "Description of state description prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for state description prompt.",
+            "type": "text",
+            "content": "The {state} state has the following instruction:\n {state_description}",
+            "variables": {
+              "state": "",
+              "state_description": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "agent_feedback_description_prompt",
+    "description": "Description of agent feedback description prompt",
+    "prompts": [
+      {
+        "prompt_id": "AGENT_FEEDBACK_DESCRIPTION_PROMPT",
+        "description": "Description of agent feedback description prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for agent feedback description prompt.",
+            "type": "text",
+            "content": "You are an intelligent assistant helping the user to complete their task.\n\nYou have the following task to complete:\n{task}\n\nContext of your work is as follows:\n{context}\n\nYou have the following options to continue completing this task:\n\n{options}\n\nUse polite and engaging language, and ask the user what they want you to help them with next. No need to greet and keep it short and concise.\n\nIf you think the context is not enough to choose an action, ask the user for more information.",
+            "variables": {
+              "task": "",
+              "context": "",
+              "options": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "react_policy_prompt",
+    "description": "Description of react policy prompt",
+    "prompts": [
+      {
+        "prompt_id": "SELECTION_DESCRIPTION",
+        "description": "Description of react policy prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for react policy selection description.",
+            "type": "text",
+            "content": "{role_description}\\n\\n{output_instruction}\\n\\n**Task Description**: {task_description}\\n\\n**IMPORTANT - Available Actions**:\\n{possible_actions}\\n\\nYou MUST ONLY select from the actions listed above. DO NOT try to use any actions that are not explicitly listed.\\n\\n**Task Context**:\\n{task_context}\\n\\n**History of Previous Actions**:\\n{history_of_previous_actions}\\n\\nSTRICT REQUIREMENTS:\\n1. You must ONLY select actions that are listed under 'Available Actions' above\\n2. If you need an action that is not listed, you must work with the actions that ARE available\\n3. Respond ONLY in the JSON format specified below\\n4. No additional text or explanations - ONLY the JSON response\\n\\nResponse Format:\\n{response_format}\\n\\nEnsure the response can be parsed by Python json.loads.",
+            "variables": {
+              "role_description": "",
+              "output_instruction": "",
+              "task_description": "",
+              "possible_actions": "",
+              "task_context": "",
+              "history_of_previous_actions": "",
+              "response_format": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "prompt_parent_id": "react_sm_policy_prompt",
+    "description": "Description of react sm policy prompt",
+    "prompts": [
+      {
+        "prompt_id": "SELECTION_DESCRIPTION",
+        "description": "Description of react sm policy prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for react state machine policy selection description.",
+            "type": "text",
+            "content": "{role_description}\\n\\n## History of Previous Actions\\n{history_of_previous_actions}\\n\\nYou have a state machine to help you with the action execution. You are currently in the {state} state.\\n{state_description}\\n\\n## Possible Actions:\\n{possible_actions}\\n\\n**Task Description**: {task_description}\\n\\nYou should only select the actions specified in **Possible Actions**.\\nYou should only respond in JSON format as described below without any extra text.\\n\\nResponse Format:\\n{response_format}\\n\\nEnsure the response can be parsed by Python json.loads.\\n\\n{output_instruction}",
+            "variables": {
+              "role_description": "",
+              "context": "",
+              "history_of_previous_actions": "",
+              "state": "",
+              "state_description": "",
+              "possible_actions": "",
+              "task_description": "",
+              "response_format": "",
+              "output_instruction": ""
+            },
+            "response_format": {}
+          }
+        ]
+      },
+      {
+        "prompt_id": "STATE_DESCRIPTION_PROMPT",
+        "description": "Description of state description prompt",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for state description prompt in react state machine policy.",
+            "type": "text",
+            "content": "The {state} state has the following instruction:\n{state_description}",
+            "variables": {
+              "state": "",
+              "state_description": ""
+            },
+            "response_format": {}
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/tests/data/prompts.json
+++ b/src/tests/data/prompts.json
@@ -1,99 +1,111 @@
-{
-  "addition_prompts": [
-    {
-      "name": "addition_prompts",
-      "description": "prompt to add numbers and return structured output",
-      "prompts": [
-        {
-          "name": "add_numbers_text",
-          "description": "prompt to add numbers and return structured output",
-          "type": "text",
-          "version": "1.0",
-          "content": "Add {first_num} and {second_num}"
-          ,
-          "variables": {
-            "first_num": 5,
-            "second_num": 10
-          },
-          "response_format": {
-            "type": "json_schema",
-            "json_schema": {
-              "name": "addition_result",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "result": { "type": "number" },
-                  "explanation": { "type": "string" }
-                },
-                "required": ["result", "explanation"]
-              }
-            }
-          }
-        },
-        {
-          "name": "add_numbers_chat",
-          "description": "prompt to add numbers as chat",
-          "version": "1.0",
-          "type": "chat",
-          "content": [
-            {
-              "role": "system",
-              "content": "You are a helpful assistant that performs simple arithmetic operations."
+[
+  {
+    "prompt_parent_id": "addition_prompts",
+    "description": "prompt to add numbers and return structured output",
+    "prompts": [
+      {
+        "prompt_id": "add_numbers_text",
+        "description": "prompt to add numbers and return structured output",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for text addition",
+            "type": "text",
+            "content": "Add {first_num} and {second_num}",
+            "variables": {
+              "first_num": 5,
+              "second_num": 10
             },
-            {
-              "role": "user",
-              "content": "Add {first_num} and {second_num}"
-            }
-          ],
-          "variables": {
-            "first_num": 5,
-            "second_num": 10
-          },
-          "response_format": {
-            "type": "json_schema",
-            "json_schema": {
-              "name": "addition_result",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "result": { "type": "number" },
-                  "explanation": { "type": "string" }
-                },
-                "required": ["result", "explanation"]
+            "response_format": {
+              "type": "json_schema",
+              "json_schema": {
+                "name": "addition_result",
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": { "type": "number" },
+                    "explanation": { "type": "string" }
+                  },
+                  "required": ["result", "explanation"]
+                }
               }
             }
           }
-        },
-        {
-          "name": "add_numbers_json",
-          "description": "prompt to add numbers as JSON",
-          "version": "1.0",
-          "type": "json",
-          "content": {
-            "operation": "add",
-            "first_number": "{first_num}",
-            "second_number": "{second_num}"
-          },
-          "variables": {
-            "first_num": 5,
-            "second_num": 10
-          },
-          "response_format": {
-            "type": "json_schema",
-            "json_schema": {
-              "name": "addition_result",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "result": { "type": "number" },
-                  "explanation": { "type": "string" }
-                },
-                "required": ["result", "explanation"]
+        ]
+      },
+      {
+        "prompt_id": "add_numbers_chat",
+        "description": "prompt to add numbers as chat",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for chat addition",
+            "type": "chat",
+            "content": [
+              {
+                "role": "system",
+                "content": "You are a helpful assistant that performs simple arithmetic operations."
+              },
+              {
+                "role": "user",
+                "content": "Add {first_num} and {second_num}"
+              }
+            ],
+            "variables": {
+              "first_num": 5,
+              "second_num": 10
+            },
+            "response_format": {
+              "type": "json_schema",
+              "json_schema": {
+                "name": "addition_result",
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": { "type": "number" },
+                    "explanation": { "type": "string" }
+                  },
+                  "required": ["result", "explanation"]
+                }
               }
             }
           }
-        }
-      ]
-    }
-  ]
-}
+        ]
+      },
+      {
+        "prompt_id": "add_numbers_json",
+        "description": "prompt to add numbers as JSON",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version for JSON addition",
+            "type": "json",
+            "content": {
+              "operation": "add",
+              "first_number": "{first_num}",
+              "second_number": "{second_num}"
+            },
+            "variables": {
+              "first_num": 5,
+              "second_num": 10
+            },
+            "response_format": {
+              "type": "json_schema",
+              "json_schema": {
+                "name": "addition_result",
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": { "type": "number" },
+                    "explanation": { "type": "string" }
+                  },
+                  "required": ["result", "explanation"]
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/tests/unit_tests/prompts/test_prompt_template_loader.py
+++ b/src/tests/unit_tests/prompts/test_prompt_template_loader.py
@@ -1,69 +1,77 @@
-import json
-import pytest
 from unittest.mock import patch
 from sherpa_ai.prompts.prompt_template_loader import PromptTemplate
 
-mock_json_data = {
-    "addition_prompts": [
-        {
-            "name": "addition_prompts",
-            "description": "prompt to add numbers and return structured output",
-            "prompts": [
-                {
-                    "name": "add_numbers_chat",
-                    "version": "1.0",
-                    "type": "chat",
-                    "description": "prompt to add numbers as chat",
-                    "content": [
-                        {"role": "system", "content": "You are a helpful assistant that performs simple arithmetic operations."},
-                        {"role": "user", "content": "Add {first_num} and {second_num}"}
-                    ],
-                    "variables": {"first_num": 5, "second_num": 10},
-                    "response_format": {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "addition_result",
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "result": {"type": "number"},
-                                    "explanation": {"type": "string"}
-                                },
-                                "required": ["result", "explanation"]
+
+# Mock JSON data to simulate prompts.json with the 'versions' list
+mock_json_data = [
+    {
+        "prompt_parent_id": "addition_prompts",
+        "description": "prompt to add numbers and return structured output",
+        "prompts": [
+            {
+                "prompt_id": "add_numbers_chat",
+                "description": "prompt to add numbers as chat",
+                "versions": [
+                    {
+                        "version": "1.0",
+                        "change_log": "Initial version",
+                        "type": "chat",
+                        "content": [
+                            {"role": "system", "content": "You are a helpful assistant that performs simple arithmetic operations."},
+                            {"role": "user", "content": "Add {first_num} and {second_num}"}
+                        ],
+                        "variables": {"first_num": 5, "second_num": 10},
+                        "response_format": {
+                            "type": "json_schema",
+                            "json_schema": {
+                                "name": "addition_result",
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {"type": "number"},
+                                        "explanation": {"type": "string"}
+                                    },
+                                    "required": ["result", "explanation"]
+                                }
                             }
                         }
                     }
-                },
-                {
-                    "name": "add_numbers_json",
-                    "version": "1.0",
-                    "type": "json",
-                    "description": "prompt to add numbers as JSON",
-                    "content": {
-                        "operation": "add",
-                        "first_number": "{first_num}",
-                        "second_number": "{second_num}"
-                    },
-                    "variables": {"first_num": 5, "second_num": 10},
-                    "response_format": {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "addition_result",
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "result": {"type": "number"},
-                                    "explanation": {"type": "string"}
-                                },
-                                "required": ["result", "explanation"]
+                ]
+            },
+            {
+                "prompt_id": "add_numbers_json",
+                "description": "prompt to add numbers as JSON",
+                "versions": [
+                    {
+                        "version": "1.0",
+                        "change_log": "Initial version",
+                        "type": "json",
+                        "content": {
+                            "operation": "add",
+                            "first_number": "{first_num}",
+                            "second_number": "{second_num}"
+                        },
+                        "variables": {"first_num": 5, "second_num": 10},
+                        "response_format": {
+                            "type": "json_schema",
+                            "json_schema": {
+                                "name": "addition_result",
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {"type": "number"},
+                                        "explanation": {"type": "string"}
+                                    },
+                                    "required": ["result", "explanation"]
+                                }
                             }
                         }
                     }
-                }
-            ]
-        }
-    ]
-}
+                ]
+            }
+        ]
+    }
+]
 
 @patch('sherpa_ai.prompts.prompt_loader.load_json')
 def test_format_prompt_chat(mock_load_json):
@@ -85,7 +93,7 @@ def test_format_prompt_json(mock_load_json):
     
     variables = {"first_num": 15, "second_num": 25}
     formatted_prompt = template.format_prompt("addition_prompts", "add_numbers_json", "1.0", variables)
-    
+
     assert formatted_prompt == {
         "operation": "add",
         "first_number": "15",
@@ -96,7 +104,7 @@ def test_format_prompt_json(mock_load_json):
 def test_get_full_formatted_prompt_chat(mock_load_json):
     mock_load_json.return_value = mock_json_data
     template = PromptTemplate("./tests/data/prompts.json")
-    
+
     variables = {"first_num": 15, "second_num": 25}
     full_prompt = template.get_full_formatted_prompt("addition_prompts", "add_numbers_chat", "1.0", variables)
 
@@ -124,7 +132,7 @@ def test_get_full_formatted_prompt_chat(mock_load_json):
 def test_get_full_formatted_prompt_json(mock_load_json):
     mock_load_json.return_value = mock_json_data
     template = PromptTemplate("./tests/data/prompts.json")
-    
+
     variables = {"first_num": 15, "second_num": 25}
     full_prompt = template.get_full_formatted_prompt("addition_prompts", "add_numbers_json", "1.0", variables)
 


### PR DESCRIPTION
# Description
> Refactor prompt structure in prompts.json to use a list structure with prompt_parent_id and versions for prompts

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

# Checklists
To speed up the review process, please follow these checklists:

## Development
- [x] The Pull Request is small and focused on one topic
- [ ] Lint rules pass locally (`make format && make lint`)
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development (`make test`)
- [ ] The changes generate no new warnings (or explain any new warnings and why they're ok)
- [x] Commit messages are detailed
- [ ] Changed code is self-explanatory and/or I added comments
- [ ] I updated the documentation (docstrings, /docs)
See the testing guidelines for help on tests, especially those involving web services.

## Code review
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] I have performed a self-review of my code
- [ ] Issue from task tracker has a link to this pull request

💔 Thank you for submitting a pull request!