### PR TITLE
Add dynamic enum handling in response schema

### DIFF
--- a/src/sherpa_ai/prompts/prompt_template_loader.py
+++ b/src/sherpa_ai/prompts/prompt_template_loader.py
@@ -5,9 +5,10 @@ them with variables. It extends the base PromptLoader to add variable
 substitution capabilities for different prompt types.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 from sherpa_ai.prompts.Base import ChatPromptVersion, TextPromptVersion, JsonPromptVersion
 from sherpa_ai.prompts.prompt_loader import PromptLoader
+import copy
 
 class PromptTemplate(PromptLoader):
     """Template loader and formatter for prompts.
@@ -83,6 +84,7 @@ class PromptTemplate(PromptLoader):
         if variables:
             final_variables.update(variables)
 
+        # Format the prompt content
         if isinstance(prompt_version_obj, ChatPromptVersion):
             formatted_prompt = []
             for message in prompt_version_obj.content:
@@ -137,12 +139,96 @@ class PromptTemplate(PromptLoader):
         else:
             raise ValueError(f"Unknown prompt version type: {type(prompt_version_obj)}")
 
+    def format_response_format(
+        self,
+        prompt_parent_id: str,
+        prompt_id: str,
+        version: str,
+        variables: Optional[Dict[str, Union[str, int, float, List]]] = None
+    ) -> Optional[Dict]:
+        """Format the response format schema by replacing variables with values.
+
+        This method specifically handles variable substitution in response format schemas,
+        including enum values in JSON schemas.
+
+        Args:
+            prompt_parent_id (str): Name of the wrapper containing the prompt.
+            prompt_id (str): ID of the prompt to format.
+            version (str): Version of the prompt to format.
+            variables (Optional[Dict[str, Union[str, int, float, List]]]): Values to
+                substitute in the schema. If None, uses defaults from JSON.
+
+        Returns:
+            Optional[Dict]: Formatted response format schema if found and successfully
+                formatted, None otherwise.
+
+        Example:
+            >>> template = PromptTemplate("prompts.json")
+            >>> formatted_schema = template.format_response_format(
+            ...     prompt_parent_id="supplement",
+            ...     prompt_id="recommendation",
+            ...     version="1.0",
+            ...     variables={"available_skus": ["SKU-001", "SKU-002", "SKU-003"]}
+            ... )
+        """
+        prompt_version_obj = self.get_prompt_version(prompt_parent_id, prompt_id, version)
+
+        if not prompt_version_obj:
+            return None
+
+        prompt_variables = prompt_version_obj.variables or {}
+        final_variables = prompt_variables.copy()
+
+        if variables:
+            final_variables.update(variables)
+
+        if not prompt_version_obj.response_format:
+            return None
+
+        formatted_response_format = copy.deepcopy(prompt_version_obj.response_format)
+
+        def replace_in_schema(data: Any) -> Any:
+            """Recursively replace variables in schema data.
+
+            Args:
+                data (Any): Data to process (dict, list, or primitive).
+
+            Returns:
+                Any: Data with variables replaced.
+            """
+            if isinstance(data, dict):
+                for key, value in data.items():
+                    if isinstance(value, str):
+                        for var_name, var_value in final_variables.items():
+                            placeholder = f"{{{var_name}}}"
+                            if placeholder in value:
+                                data[key] = value.replace(placeholder, str(var_value))
+                    elif isinstance(value, list):
+                        data[key] = replace_in_schema(value)
+                    elif isinstance(value, dict):
+                        data[key] = replace_in_schema(value)
+            elif isinstance(data, list):
+                for i, item in enumerate(data):
+                    if isinstance(item, str):
+                        for var_name, var_value in final_variables.items():
+                            if item == f"{{{var_name}}}":
+                                if isinstance(var_value, list):
+                                    data[i:i+1] = var_value
+                                    return data
+                                else:
+                                    data[i] = var_value
+                    else:
+                        data[i] = replace_in_schema(item)
+            return data
+
+        return replace_in_schema(formatted_response_format)
+
     def get_full_formatted_prompt(
         self,
         prompt_parent_id: str,
-        prompt_id: str, # Changed from name to prompt_id
+        prompt_id: str,
         version: str,
-        variables: Optional[Dict[str, Union[str, int, float]]] = None
+        variables: Optional[Dict[str, Union[str, int, float, List]]] = None
     ) -> Optional[Dict[str, Union[str, List[Dict[str, str]], Dict]]]:
         """Get a formatted prompt with metadata.
 
@@ -154,7 +240,7 @@ class PromptTemplate(PromptLoader):
             prompt_parent_id (str): Name of the wrapper containing the prompt.
             prompt_id (str): ID of the prompt to format.
             version (str): Version of the prompt to format.
-            variables (Optional[Dict[str, Union[str, int, float]]]): Values to
+            variables (Optional[Dict[str, Union[str, int, float, List]]]): Values to
                 substitute in the prompt. If None, uses defaults from JSON.
 
         Returns:
@@ -195,8 +281,13 @@ class PromptTemplate(PromptLoader):
         if not formatted_content:
             return None
 
+        # Format the response format schema as well
+        formatted_response_format = self.format_response_format(
+            prompt_parent_id, prompt_id, version, variables
+        )
+
         return {
             "description": target_prompt.description,
             "content": formatted_content,
-            "output_schema": prompt_version_obj.response_format
+            "output_schema": formatted_response_format
         }

--- a/src/tests/data/prompts.json
+++ b/src/tests/data/prompts.json
@@ -107,5 +107,62 @@
         ]
       }
     ]
+  },
+  {
+    "prompt_parent_id": "math_prompts",
+    "description": "Prompts for arithmetic with dynamic enum values",
+    "prompts": [
+      {
+        "prompt_id": "addition_with_allowed_output_format",
+        "description": "Add two numbers and choose an output format from a dynamic enum",
+        "versions": [
+          {
+            "version": "1.0",
+            "change_log": "Initial version with dynamic enum substitution for output_format",
+            "type": "text",
+            "content": [
+              "You will add two numbers.",
+              "",
+              "A: {a}",
+              "B: {b}",
+              "Allowed output formats: {allowed_output_formats}",
+              "",
+              "Return the sum using one of the allowed output formats."
+            ],
+            "variables": {
+              "a": 2,
+              "b": 3,
+              "allowed_output_formats": ""
+            },
+            "response_format": {
+              "type": "json_schema",
+              "json_schema": {
+                "name": "addition_with_format",
+                "strict": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sum": {
+                      "type": "number",
+                      "description": "The sum of a and b"
+                    },
+                    "output_format": {
+                      "type": "string",
+                      "enum": ["{allowed_output_formats}"]
+                    },
+                    "explanation": {
+                      "type": "string",
+                      "description": "Brief explanation of how the result is formatted"
+                    }
+                  },
+                  "required": ["sum", "output_format"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Description
Dynamic enum substitution in the response format
> Add directions for contributors. For example, do developers need to run `poetry install` after picking up these changes?

# Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

# Related issues
> Mention related GitHub and Linear issues. E.g. Closes #xxx or Fixes #xxx. Otherwise delete this section.

# Checklists
To speed up the review process, please follow these checklists:

## Development
- [x] The Pull Request is small and focused on one topic
- [ ] Lint rules pass locally (`make format && make lint`)
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development (`make test`)
- [ ] The changes generate no new warnings (or explain any new warnings and why they're ok)
- [ ] Commit messages are detailed
- [ ] Changed code is self-explanatory and/or I added comments
- [ ] I updated the documentation (docstrings, /docs)
See the testing guidelines for help on tests, especially those involving web services.

## Code review
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] I have performed a self-review of my code
- [ ] Issue from task tracker has a link to this pull request

💔 Thank you for submitting a pull request!