### PR TITLE
resolve inheritance diagram rendering in webpage

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,14 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+# Setup target to ensure Graphviz is available
+setup:
+	@echo "Installing required packages..."
+	pip install -r requirements.txt
+	@echo "Checking Graphviz availability..."
+	@python -c "import graphviz; print('Graphviz is available')" || echo "Warning: Graphviz not available. Inheritance diagrams may not render properly."
+
+.PHONY: help Makefile setup
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,3 +107,13 @@ inheritance_graph_attrs = {
 
 # Configure graphviz
 graphviz_output_format = 'svg'  # Use SVG for better quality
+
+# Fallback configuration for when Graphviz is not available
+try:
+    import graphviz
+    GRAPHVIZ_AVAILABLE = True
+except ImportError:
+    GRAPHVIZ_AVAILABLE = False
+    # Disable inheritance diagrams if Graphviz is not available
+    extensions.remove('sphinx.ext.inheritance_diagram')
+    extensions.remove('sphinx.ext.graphviz')

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-book-theme
 sphinx-design
 myst-parser
 sphinx_autodoc_typehints
+graphviz


### PR DESCRIPTION
# Description

- Add graphviz to docs requirements for proper diagram rendering
- Add fallback configuration when Graphviz is unavailable
- Add setup target to Makefile for dependency verification
- Gracefully handle missing Graphviz by disabling inheritance extensions

The key issue was that Sphinx's inheritance diagram feature requires the Graphviz system package to be installed