### PR TITLE
Fix/slack optional integration

### DIFF
--- a/src/.env-sample
+++ b/src/.env-sample
@@ -11,11 +11,11 @@ TEMPERATURE=                        # Only applies to the legacy task agent
 # DAILY_TOKEN_LIMIT                 # Daily limit on the number of tokens users can use.
 # INDEX_NAME_FILE_STORAGE           # The name of the collection to get or create vector db
 
-# Slack integration
-SLACK_OAUTH_TOKEN=                # from `OAuth & Permissions` page of your Slack App
-SLACK_PORT=3000                   # port for app's web server
-SLACK_SIGNING_SECRET=             # from `Basic Information` page of your Slack App
-SLACK_VERIFICATION_TOKEN=         # from `Basic Information` page of your Slack App
+# Slack integration (Optional - only needed if you want to use Slack features)
+# SLACK_OAUTH_TOKEN=                # from `OAuth & Permissions` page of your Slack App
+# SLACK_PORT=3000                   # port for app's web server
+# SLACK_SIGNING_SECRET=             # from `Basic Information` page of your Slack App
+# SLACK_VERIFICATION_TOKEN=         # from `Basic Information` page of your Slack App
 
 # Vector database settings, for embeddings. Choose from Pinecone or Chroma.
 # If none is configured, Sherpa uses an in-memory version of Chroma. If you're running

--- a/src/sherpa_ai/config/__init__.py
+++ b/src/sherpa_ai/config/__init__.py
@@ -62,6 +62,13 @@ SLACK_OAUTH_TOKEN = environ.get("SLACK_OAUTH_TOKEN")
 SLACK_VERIFICATION_TOKEN = environ.get("SLACK_VERIFICATION_TOKEN")
 SLACK_PORT = environ.get("SLACK_PORT", 3000)
 
+# Check if Slack integration is fully configured
+SLACK_ENABLED = all([
+    SLACK_SIGNING_SECRET,
+    SLACK_OAUTH_TOKEN,
+    SLACK_VERIFICATION_TOKEN,
+])
+
 # Vector database settings, for embeddings. Choose from Pinecone or Chroma.
 # If none is configured, Sherpa uses an in-memory version of Chroma. If you're running
 # Sherpa via docker-compose, Docker settings are used instead of these values.
@@ -135,23 +142,23 @@ def check_vectordb_setting():
 
 
 # Ensure all mandatory environment variables are set, otherwise exit
-if None in [
-    this.SLACK_VERIFICATION_TOKEN,
-    this.SLACK_SIGNING_SECRET,
-    this.SLACK_OAUTH_TOKEN,
-    this.SLACK_PORT,
-]:
-    logger.warning("Config: Slack environment variables not set")
-else:
-    logger.info("Config: Slack environment variables are set")
 
 if this.OPENAI_API_KEY is None:
     logger.warning("Config: OpenAI environment variables not set")
 else:
     logger.info("Config: OpenAI environment variables are set")
 
+# Slack integration status (optional)
+if this.SLACK_ENABLED:
+    logger.info("Config: Slack integration is fully configured and enabled")
+elif any([this.SLACK_SIGNING_SECRET, this.SLACK_OAUTH_TOKEN, this.SLACK_VERIFICATION_TOKEN]):
+    logger.warning("Config: Slack integration partially configured - some variables are missing")
+else:
+    logger.info("Config: Slack integration not configured (optional feature)")
+
 check_vectordb_setting()
 
 __all__ = [
     "AgentConfig",
+    "SLACK_ENABLED",
 ]


### PR DESCRIPTION
Fixed the Slack environment variable warnings by making the Slack integration optional.

- Added SLACK_ENABLED variable: This boolean variable checks if all required Slack environment variables are set
- Removed mandatory Slack checks: The previous code was treating Slack variables as mandatory and logging warnings when they weren't set
- Added intelligent Slack status logging: Now the system provides clear feedback about Slack integration status