### PR TITLE
adapt arxiv search to new response format

### DIFF
--- a/src/sherpa_ai/tools.py
+++ b/src/sherpa_ai/tools.py
@@ -126,6 +126,10 @@ class SearchArxivTool(BaseTool):
         summaries = re.findall(summary_pattern, xml_content, re.DOTALL)
         title_pattern = r"<title>(.*?)</title>"
         titles = re.findall(title_pattern, xml_content, re.DOTALL)
+
+        # Note that arXiv may return on extra title for the search feed itself
+        titles = titles[len(titles) - len(summaries):]  # align titles and summaries
+
         id_pattern = r"<id>(.*?)</id>"
         ids = re.findall(id_pattern, xml_content, re.DOTALL)
 


### PR DESCRIPTION
# Description
It seems recently the arXiv search has been changed to return an extra `title` element for the search result itself, which causes one existing test to fail. This fix aligns the number of title elements and summary elements to ensure consistency. 

# Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release


# Checklists
To speed up the review process, please follow these checklists:

## Development
- [x] The Pull Request is small and focused on one topic
- [x] Lint rules pass locally (`make format && make lint`)
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development (`make test`)
- [x] The changes generate no new warnings (or explain any new warnings and why they're ok)
- [x] Commit messages are detailed
- [x] Changed code is self-explanatory and/or I added comments
- [ ] I updated the documentation (docstrings, /docs)
See the testing guidelines for help on tests, especially those involving web services.

## Code review
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] I have performed a self-review of my code
- [ ] Issue from task tracker has a link to this pull request

💔 Thank you for submitting a pull request!