### PR TITLE
build(deps): bump mcp from 1.28.1 to 2.0.0 in /src (hardened)

### DIFF
--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -7210,4 +7210,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.14,>=3.10"
-content-hash = "79a448728a85c44641ad9b79bfee561a6e8c744ef2a3ce41078613f33a69508b"
+content-hash = "d2f4fe1a207c68a39ea0ed7c1e12b423c0fe6d68f5ab0df70bba6468e9c26e37"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -33,7 +33,7 @@ transitions = "^0.9.2"
 pydash = "^8.0.3"
 pykka = "^4.2.0"
 spacy = "3.8.14"
-mcp = "^1.12.4"
+mcp = ">=1.12.4,<3.0.0"
 # combined_number_extractor (used by NumberValidation) calls word_to_float on
 # almost any text, so this must be a hard dependency, not optional — a normal
 # install without the optional group would otherwise raise ImportError.

--- a/src/sherpa_ai/actions/sherpa_mcp_adapter.py
+++ b/src/sherpa_ai/actions/sherpa_mcp_adapter.py
@@ -154,8 +154,11 @@ class MCPServerToolsToSherpaActions(BaseAction):
             self.actions.append(action_instance)
 
     def _parse_args_from_tool(self, tool):
-        if hasattr(tool, 'inputSchema') and tool.inputSchema and 'properties' in tool.inputSchema:
-            return {k: v.get('description', '') for k, v in tool.inputSchema['properties'].items()}
+        # mcp>=2.0 renamed Tool.inputSchema to Tool.input_schema; support both
+        # so this keeps working across the v1/v2 boundary.
+        schema = getattr(tool, 'input_schema', None) or getattr(tool, 'inputSchema', None)
+        if schema and 'properties' in schema:
+            return {k: v.get('description', '') for k, v in schema['properties'].items()}
         desc = getattr(tool, 'description', '')
         args = {}
         if desc:

--- a/src/tests/unit_tests/mcp/test_sherpa_mcp_adapter.py
+++ b/src/tests/unit_tests/mcp/test_sherpa_mcp_adapter.py
@@ -40,7 +40,10 @@ def mock_llm():
 
 @pytest.fixture
 def mock_tool():
-    tool = MagicMock()
+    # spec constrains attribute access to this real v1 Tool surface, so
+    # unset attributes (e.g. input_schema) raise AttributeError like the
+    # real object instead of silently auto-vivifying a truthy stub.
+    tool = MagicMock(spec=["name", "description", "inputSchema"])
     tool.name = "test_tool"
     tool.description = "A test tool"
     tool.inputSchema = {
@@ -50,9 +53,21 @@ def mock_tool():
     }
     return tool
 
+class ToolV2Schema:
+    """Mimics mcp>=2.0's Tool, which exposes input_schema (snake_case) and
+    no longer has inputSchema at all."""
+    name = "test_tool"
+    description = "A test tool"
+    input_schema = {
+        "properties": {
+            "foo": {"type": "string", "description": "A foo param"}
+        }
+    }
+
+
 @pytest.fixture
 def mock_tool_no_schema():
-    tool = MagicMock()
+    tool = MagicMock(spec=["name", "description", "inputSchema"])
     tool.name = "test_tool"
     tool.description = "foo: A foo param\nbar: A bar param"
     tool.inputSchema = None
@@ -75,6 +90,14 @@ class TestMCPServerToolsToSherpaActions:
         args = adapter._parse_args_from_tool(mock_tool)
         assert "foo" in args
         assert args["foo"] == "A foo param"
+
+    def test_parse_args_from_tool_with_v2_snake_case_schema(self, adapter):
+        # Regression test: mcp>=2.0 renamed Tool.inputSchema to
+        # Tool.input_schema. Without the fallback, this silently degrades to
+        # parsing args out of the free-text description instead of the
+        # real schema.
+        args = adapter._parse_args_from_tool(ToolV2Schema())
+        assert args == {"foo": "A foo param"}
 
     def test_parse_args_from_tool_without_input_schema(self, adapter, mock_tool_no_schema):
         args = adapter._parse_args_from_tool(mock_tool_no_schema)


### PR DESCRIPTION
## Summary
Supersedes #533. Same version bump, plus a fix for a regression the original PR's test suite couldn't have caught.

`mcp` 2.0.0 renames `Tool.inputSchema` to `Tool.input_schema`. `sherpa_mcp_adapter.py`'s `_parse_args_from_tool` used `hasattr(tool, 'inputSchema')`, which silently returns `False` post-upgrade (the `AttributeError` is swallowed), degrading to parsing tool arguments out of the free-text description instead of the real JSON schema. No crash, no test failure — just wrong/missing arg descriptions for every real MCP tool.

The existing tests couldn't catch this because `mock_tool` was a bare `MagicMock()`, which auto-vivifies any attribute access (including `input_schema`) as a truthy stub — masking exactly this class of regression.

## Changes
- `_parse_args_from_tool` now checks both `input_schema` (v2) and `inputSchema` (v1)
- Tightened `mock_tool`/`mock_tool_no_schema` fixtures with `spec=` so they raise `AttributeError` like the real object instead of silently auto-vivifying
- Added a regression test for the v2 (snake_case) schema shape

Verified by mutating the fix back to `inputSchema`-only and confirming the new test fails, then reverting and confirming green. Full test suite (385 passed, 2 skipped) run locally against the real installed `mcp==2.0.0`, not mocked.

## Test plan
- [x] `pytest tests/unit_tests/mcp/` — 11 passed
- [x] Full suite — 385 passed, 2 skipped, with real `mcp==2.0.0` installed
- [x] Mutation test: reverted fix to `inputSchema`-only → new regression test failed as expected; re-applied fix → passed again
- [x] CI on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>