### PR TITLE
build(deps): bump blueprint_parser_creator deps (python-dotenv, loguru, regex, langchain-community, pytest)

### DIFF
--- a/demo/blueprint_parser_creator/blueprint_utils.py
+++ b/demo/blueprint_parser_creator/blueprint_utils.py
@@ -35,7 +35,7 @@ import os
 # import re  # No longer needed - removed regex-based methods
 from collections import defaultdict
 from dotenv import load_dotenv
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from pathlib import Path
 from shapely.geometry import Polygon, Point, LineString
 from shapely.ops import unary_union

--- a/demo/blueprint_parser_creator/main.py
+++ b/demo/blueprint_parser_creator/main.py
@@ -52,7 +52,7 @@ from sherpa_ai.config.task_config import AgentConfig
 from sherpa_ai.agents.qa_agent import QAAgent
 
 # LangChain's ChatOpenAI model as the LLM for the Sherpa agent.
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/demo/blueprint_parser_creator/requirements.txt
+++ b/demo/blueprint_parser_creator/requirements.txt
@@ -3,18 +3,19 @@
 
 sherpa-ai>=0.1.0
 streamlit>=1.28.0
-langchain-community>=0.0.10
+langchain-community>=0.4.2
 langchain-core>=0.1.0
+langchain-openai>=1.0.0
 openai>=1.0.0
 ezdxf>=1.1.0
 shapely>=2.0.0
 cloudconvert>=2.3.0
 pydantic>=2.0.0
-python-dotenv>=1.0.0
-loguru>=0.7.0
+python-dotenv>=1.2.2
+loguru>=0.7.3
 httpx>=0.25.0
 jsonschema>=4.19.0
-regex>=2023.0.0
+regex>=2026.7.19
 pathlib2>=2.3.7
 numpy>=1.24.0
 # numba>=0.58.0
@@ -23,5 +24,5 @@ numpy>=1.24.0
 # pillow>=10.0.0
 
 # Testing dependencies
-pytest>=7.0.0
+pytest>=9.1.1
 pytest-mock>=3.10.0


### PR DESCRIPTION
## Summary
Supersedes #521, #522, #524, #527, #529 — folded into one branch since they're all independent single-line bumps to the same `requirements.txt`.

| Package | From | To | PR |
|---|---|---|---|
| python-dotenv | >=1.0.0 | >=1.2.2 | #521 |
| loguru | >=0.7.0 | >=0.7.3 | #522 |
| langchain-community | >=0.0.10 | >=0.4.2 | #524 |
| regex | >=2023.0.0 | >=2026.7.19 | #527 |
| pytest | >=7.0.0 | >=9.1.1 | #529 |

## Real bug found and fixed
This demo has its own test suite, but CI never runs it — the earlier PRs only had CI's "does it install" check to go on. Running the tests for real (with the bumped versions actually installed, not mocked) surfaced a genuine break: `langchain_community.chat_models.ChatOpenAI` no longer exists on current `langchain-community`. This isn't new from this bump — the `>=` pins here always resolve to latest, so it was already broken before today. Fixed both `main.py` and `blueprint_utils.py` to import `ChatOpenAI` from `langchain_openai` (the actively maintained package) instead, and added `langchain-openai` explicitly to `requirements.txt` since the code imports it directly.

Two pre-existing test failures are unrelated to any of this and left alone (out of scope): `test_imports` requires `CLOUDCONVERT_API_KEY` to be set in the environment, and `test_environment_variables` checks `tests/.env-sample` instead of the real `.env-sample` at the demo root.

## Test plan
- [x] Fresh venv, `pip install -r requirements.txt` with all 5 bumped versions resolved
- [x] `pytest tests/` — 11 passed, 2 pre-existing failures (unrelated, documented above)
- [x] Confirmed the `ChatOpenAI` import break reproduces even without the version bump (latent, not introduced by this PR)
- [x] CI on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>