### PR TITLE
Wire up six dead config settings

### DIFF
--- a/src/.env-sample
+++ b/src/.env-sample
@@ -25,10 +25,6 @@ OPENAI_API_KEY=                     # OpenAI API key
 # Github auth for extracting readme files from GitHub repositories. Optional.
 # GITHUB_AUTH_TOKEN=                # Authorization token for Github API
 
-# Amazon Web Sevices - for transcript summaries. Optional.
-# AWS_ACCESS_KEY=                   # AWS Access Key
-# AWS_SECRET_KEY=                   # AWS Secret Key
-
 # Usage tracking logging settings
 USAGE_LOG_TO_S3=false               # Enable S3 logging for usage data (default: false)
 USAGE_LOG_TO_FILE=true            # Enable local file logging for usage data (default: true)

--- a/src/sherpa_ai/config/__init__.py
+++ b/src/sherpa_ai/config/__init__.py
@@ -85,9 +85,6 @@ SERPER_API_KEY = environ.get("SERPER_API_KEY")
 # Github auth for extracting readme files from GitHub repositories. Optional.
 GITHUB_AUTH_TOKEN = environ.get("GITHUB_AUTH_TOKEN")
 
-# Amazon Web Sevices - for transcript summaries. Optional.
-AWS_ACCESS_KEY = environ.get("AWS_ACCESS_KEY")
-AWS_SECRET_KEY = environ.get("AWS_SECRET_KEY")
 
 # Configure logger. To get JSON serialization, set serialize=True.
 # See https://loguru.readthedocs.io/en/stable/ for info on Loguru features.

--- a/src/sherpa_ai/cost_tracking/logger.py
+++ b/src/sherpa_ai/cost_tracking/logger.py
@@ -40,11 +40,12 @@ class UsageLogger:
         usage_metadata: Optional[Dict[str, Any]] = None
     ):
         """Log usage data and check cost thresholds."""
-        # Update user cost tracking
-        self.user_costs[user_id] = self.user_costs.get(user_id, 0.0) + cost
-        
-        # Check cost thresholds and send alerts
-        self._check_cost_thresholds(user_id, self.user_costs[user_id])
+        if cfg.ENABLE_COST_TRACKING:
+            # Update user cost tracking
+            self.user_costs[user_id] = self.user_costs.get(user_id, 0.0) + cost
+
+            # Check cost thresholds and send alerts
+            self._check_cost_thresholds(user_id, self.user_costs[user_id])
         
         # Log usage data if enabled
         if not self.log_to_file:

--- a/src/sherpa_ai/cost_tracking/pricing.py
+++ b/src/sherpa_ai/cost_tracking/pricing.py
@@ -117,7 +117,7 @@ class PricingManager:
     def __init__(self, config_path: Optional[str] = None):
         """Initialize the pricing manager."""
         self.pricing_data = {}
-        self._load_pricing_config(config_path)
+        self._load_pricing_config(config_path or cfg.MODEL_PRICING_CONFIG_PATH)
     
     def _load_pricing_config(self, config_path: Optional[str] = None):
         """Load pricing configuration from JSON file."""

--- a/src/sherpa_ai/database/user_usage_tracker.py
+++ b/src/sherpa_ai/database/user_usage_tracker.py
@@ -277,32 +277,33 @@ class UserUsageTracker:
         
         # Get current usage
         current_usage = self._get_sum_of_tokens_since_last_reset(user_id)
-        
+        remaining_tokens = self.max_daily_token - current_usage
+
         # Use total_tokens from usage_metadata if available, otherwise calculate
         if usage_metadata and "total_tokens" in usage_metadata:
             total_tokens = usage_metadata["total_tokens"]
         else:
             total_tokens = input_tokens + output_tokens
-        
+
         # Check limits
         if total_tokens > self.max_daily_token:
             return {
-                "token-left": 0,
+                "token-left": remaining_tokens,
                 "can_execute": False,
                 "message": "Your request exceeds token limit. Try using smaller context.",
                 "time_left": ""
             }
-        
+
         if current_usage + total_tokens > self.max_daily_token:
             return {
-                "token-left": self.max_daily_token - current_usage,
+                "token-left": remaining_tokens,
                 "can_execute": False,
-                "message": "Daily token limit exceeded.",
+                "message": cfg.DAILY_LIMIT_REACHED_MESSAGE,
                 "time_left": ""
             }
-        
+
         return {
-            "token-left": self.max_daily_token - current_usage - total_tokens,
+            "token-left": remaining_tokens,
             "can_execute": True,
             "message": "",
             "time_left": ""
@@ -513,25 +514,6 @@ class UserUsageTracker:
     def is_in_whitelist(self, user_id: str) -> bool:
         """Check if user is in whitelist."""
         return self.session.query(Whitelist).filter_by(user_id=user_id).first() is not None
-    
-    def check_usage(self, user_id: str, input_tokens: int, output_tokens: int, 
-                   usage_metadata: Dict[str, Any] = None) -> dict:
-        """Check usage limits."""
-        # Use total_tokens from usage_metadata if available
-        if usage_metadata and "total_tokens" in usage_metadata:
-            total_tokens = usage_metadata["total_tokens"]
-        else:
-            total_tokens = input_tokens + output_tokens
-        
-        current_usage = self._get_sum_of_tokens_since_last_reset(user_id)
-        remaining_tokens = self.max_daily_token - current_usage
-        
-        return {
-            "can_execute": total_tokens <= remaining_tokens,
-            "token-left": remaining_tokens,
-            "current_usage": current_usage,
-            "requested_tokens": total_tokens
-        }
     
     def get_usage_metadata_statistics(self, user_id: Optional[str] = None) -> Dict[str, Any]:
         """Get detailed usage statistics from usage metadata."""

--- a/src/sherpa_ai/scrape/file_scraper.py
+++ b/src/sherpa_ai/scrape/file_scraper.py
@@ -152,6 +152,12 @@ class QuestionWithFileHandler:
 
         # Check if the request was successful (HTTP status code 200)
         if response.status_code == 200:
+            if len(response.content) > cfg.FILE_SIZE_LIMIT:
+                return {
+                    "status": "error",
+                    "message": f"File size exceeds the limit of {cfg.FILE_SIZE_LIMIT} bytes.",
+                }
+
             content_data = ""
             if file["filetype"] == "pdf":
                 # Open the local file and write the content of the downloaded file

--- a/src/tests/integration_tests/test_usage_tracker.py
+++ b/src/tests/integration_tests/test_usage_tracker.py
@@ -158,6 +158,9 @@ def test_check_usage_limits_remaining_tokens(tracker, mock_s3_client):
     # Try to use more than remaining - should fail
     check_usage = tracker.check_usage(user_id="jack", input_tokens=500, output_tokens=600)
     assert check_usage["can_execute"] is False
+    # The user-facing message should come from cfg.DAILY_LIMIT_REACHED_MESSAGE,
+    # not a hardcoded string that ignores the configured setting.
+    assert check_usage["message"] == cfg.DAILY_LIMIT_REACHED_MESSAGE
 
 
 # # TODO mock time or remove this entirely

--- a/src/tests/unit_tests/cost_tracking/test_cost_tracking.py
+++ b/src/tests/unit_tests/cost_tracking/test_cost_tracking.py
@@ -86,6 +86,29 @@ class TestPricingManager:
         finally:
             os.unlink(temp_file)
 
+    def test_config_path_falls_back_to_env_setting(self):
+        """PricingManager() with no explicit config_path should still pick up
+        cfg.MODEL_PRICING_CONFIG_PATH (set via the MODEL_PRICING_CONFIG_PATH
+        env var) instead of silently ignoring it."""
+        custom_pricing = {
+            "env-configured-model": {
+                "input_price_per_1k": 0.001,
+                "output_price_per_1k": 0.002,
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(custom_pricing, f)
+            temp_file = f.name
+
+        try:
+            with patch("sherpa_ai.cost_tracking.pricing.cfg.MODEL_PRICING_CONFIG_PATH", temp_file):
+                pricing = PricingManager()
+
+            assert "env-configured-model" in pricing.pricing_data
+        finally:
+            os.unlink(temp_file)
+
     def test_get_pricing(self):
         """Test getting pricing information."""
         pricing = PricingManager()
@@ -198,6 +221,23 @@ class TestCostThresholdAlerts:
         assert call_args[1]["cost_percentage"] == 80.0
         assert call_args[1]["alert_level"] == "WARNING"
         assert call_args[1]["threshold"] == 80
+
+    def test_disabled_cost_tracking_suppresses_alerts(self):
+        """cfg.ENABLE_COST_TRACKING=False should turn off cost tracking and
+        alerting entirely, not just be an ignored setting."""
+        alert_callback = Mock()
+        logger = UsageLogger(
+            daily_cost_limit=10.0,
+            alert_threshold=0.8,
+            alert_callback=alert_callback
+        )
+
+        with patch("sherpa_ai.cost_tracking.logger.cfg.ENABLE_COST_TRACKING", False):
+            # Usage that would normally trigger both the 80% and 100% alerts
+            logger.log_usage("user1", 10.0, "gpt-4o")
+
+        alert_callback.assert_not_called()
+        assert logger.get_user_cost("user1") == 0.0
 
     def test_100_percent_alert(self):
         """Test that 100% threshold alert is triggered."""

--- a/src/tests/unit_tests/scrape/test_file_scraper_size_limit.py
+++ b/src/tests/unit_tests/scrape/test_file_scraper_size_limit.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+from sherpa_ai.scrape.file_scraper import QuestionWithFileHandler
+
+
+def _make_handler():
+    return QuestionWithFileHandler(
+        question="what does this say?",
+        files=[{
+            "id": "f1",
+            "filetype": "txt",
+            "mimetype": "text/plain",
+            "url_private_download": "https://example.com/f.txt",
+        }],
+        token="token",
+        user_id="user1",
+        team_id="team1",
+        llm=None,
+    )
+
+
+def _mock_response(content: bytes):
+    response = MagicMock()
+    response.status_code = 200
+    response.content = content
+    return response
+
+
+def test_download_file_rejects_oversized_file():
+    handler = _make_handler()
+    oversized_content = b"x" * 10
+
+    with patch("sherpa_ai.scrape.file_scraper.safe_get", return_value=_mock_response(oversized_content)), \
+         patch("sherpa_ai.scrape.file_scraper.cfg.FILE_SIZE_LIMIT", 5):
+        result = handler.download_file(handler.files[0])
+
+    assert result["status"] == "error"
+    assert "size" in result["message"].lower()
+
+
+def test_download_file_accepts_file_within_limit():
+    handler = _make_handler()
+    small_content = b"hello world"
+
+    with patch("sherpa_ai.scrape.file_scraper.safe_get", return_value=_mock_response(small_content)), \
+         patch("sherpa_ai.scrape.file_scraper.cfg.FILE_SIZE_LIMIT", 1000):
+        result = handler.download_file(handler.files[0])
+
+    assert result["status"] == "success"
+    assert result["data"] == "hello world"


### PR DESCRIPTION
## Summary
Fixes #517. Six settings in `sherpa_ai/config/__init__.py` were defined and documented but never read anywhere.

- **`MODEL_PRICING_CONFIG_PATH`** — `PricingManager.__init__` now falls back to it when no explicit `config_path` is given.
- **`ENABLE_COST_TRACKING`** — `UsageLogger.log_usage` now gates cost accumulation and threshold alerting behind it, so it can actually be turned off (usage-file logging is unaffected).
- **`FILE_SIZE_LIMIT`** — enforced in `QuestionWithFileHandler.download_file` right after the response comes back, alongside the existing `FILE_TOKEN_LIMIT` check.
- **`DAILY_LIMIT_REACHED_MESSAGE`** — returned from `UserUsageTracker.check_usage` when the daily limit is hit, instead of a hardcoded string.
- **`AWS_ACCESS_KEY` / `AWS_SECRET_KEY`** — deleted per the issue's suggestion. `backup.py`'s `boto3.client("s3")` never read them; boto3 uses its own standard credential chain, and these names weren't even the standard ones boto3 looks for.

## A bigger bug found along the way
Wiring `DAILY_LIMIT_REACHED_MESSAGE` surfaced something worse: `UserUsageTracker` had **two** `check_usage` method definitions. Python silently uses the second (later) one everywhere — the first, richer implementation (with `message`, whitelist handling, `time_left`) was completely unreachable dead code, even though it matches the class's own documented example in `database/__init__.py`. The live (second) definition dropped all of that.

Removed the dead duplicate and kept the richer implementation, but had to reconcile a real semantic disagreement between the two: they computed `token-left` differently (remaining *before* vs *after* the pending request). Kept the "before" semantics since that's what the existing integration test already asserted.

## Verification
Each of the 5 fixes has a dedicated test. Each was verified by mutating the fix back out and confirming the corresponding test fails, then reverting:
- `MODEL_PRICING_CONFIG_PATH` fallback removed → `test_config_path_falls_back_to_env_setting` fails
- `ENABLE_COST_TRACKING` gate removed → `test_disabled_cost_tracking_suppresses_alerts` fails
- `FILE_SIZE_LIMIT` check removed → `test_download_file_rejects_oversized_file` fails
- `DAILY_LIMIT_REACHED_MESSAGE` reverted to hardcoded string → `test_check_usage_limits_remaining_tokens`'s new assertion fails

## Test plan
- [x] Full suite — 388 passed, 2 skipped
- [x] 4 mutation tests, one per fix, each caught and reverted
- [x] CI on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>